### PR TITLE
Make binder_induction useable in more situations

### DIFF
--- a/STLC.thy
+++ b/STLC.thy
@@ -949,10 +949,6 @@ apply (rule iffD1[OF fun_cong[OF fun_cong [OF fset.rel_eq]]])
   done
 lemmas Ty_AbsE' = Ty_AbsE''[unfolded prod_sets_simps]
 
-context begin
-ML_file \<open>./Tools/binder_induction.ML\<close>
-end
-
 lemma context_invariance: "\<Gamma> \<turnstile>\<^sub>t\<^sub>y e : \<tau>' \<Longrightarrow> \<forall>x\<in>FFVars_terms e. \<forall>\<tau>. (x, \<tau>) |\<in>| \<Gamma> \<longrightarrow> (x, \<tau>) |\<in>| \<Gamma>' \<Longrightarrow> \<Gamma>' \<turnstile>\<^sub>t\<^sub>y e : \<tau>'"
 proof (binder_induction \<Gamma> e \<tau>' arbitrary: \<Gamma>' avoiding: \<Gamma>' rule: Ty_fresh_induct_param)
   case (Ty_Var x \<tau> \<Gamma> \<Gamma>')

--- a/STLC.thy
+++ b/STLC.thy
@@ -816,7 +816,7 @@ lemma Ty_AbsE:
   apply (rule conjI refl)+
   done
 
-lemma Ty_AbsE':
+lemma Ty_AbsE'':
   assumes "\<Gamma> \<turnstile>\<^sub>t\<^sub>y Abs x \<tau>\<^sub>1 e : \<tau>" "x \<notin> \<Union>(Basic_BNFs.fsts ` fset \<Gamma>)"
 and "\<And>\<tau>\<^sub>2. \<tau> = (\<tau>\<^sub>1 \<rightarrow> \<tau>\<^sub>2) \<Longrightarrow> x \<sharp> \<Gamma> \<Longrightarrow> \<Gamma>,x:\<tau>\<^sub>1 \<turnstile>\<^sub>t\<^sub>y e : \<tau>\<^sub>2 \<Longrightarrow> P"
 shows "P"
@@ -947,6 +947,7 @@ apply (rule iffD1[OF fun_cong[OF fun_cong [OF fset.rel_eq]]])
     apply assumption
     done
   done
+lemmas Ty_AbsE' = Ty_AbsE''[unfolded prod_sets_simps]
 
 lemma context_invariance: "\<Gamma> \<turnstile>\<^sub>t\<^sub>y e : \<tau>' \<Longrightarrow> \<forall>x\<in>FFVars_terms e. \<forall>\<tau>. (x, \<tau>) |\<in>| \<Gamma> \<longrightarrow> (x, \<tau>) |\<in>| \<Gamma>' \<Longrightarrow> \<Gamma>' \<turnstile>\<^sub>t\<^sub>y e : \<tau>'"
 proof (binder_induction \<Gamma> e \<tau>' arbitrary: \<Gamma>' avoiding: \<Gamma>' rule: Ty_fresh_induct_param)
@@ -988,11 +989,11 @@ next
 next
   case (Abs y \<tau>\<^sub>1 e \<Gamma> \<tau>)
   then have 1: "y \<notin> tvIImsupp_tvsubst (tvVVr_tvsubst(x:=v))" by (simp add: tvIImsupp_tvsubst_def tvSSupp_tvsubst_def)
-  have "y \<notin> \<Union>(Basic_BNFs.fsts ` fset (\<Gamma>,x:\<tau>'))" using Abs(1) unfolding fresh_def by auto
-  then obtain \<tau>\<^sub>2 where 2: "(\<Gamma>,x:\<tau>'),y:\<tau>\<^sub>1 \<turnstile>\<^sub>t\<^sub>y e : \<tau>\<^sub>2" "\<tau> = (\<tau>\<^sub>1 \<rightarrow> \<tau>\<^sub>2)" using Abs(3) Ty_AbsE' by metis
+  have "y \<notin> fst ` fset (\<Gamma>,x:\<tau>')" using Abs(1,2) unfolding fresh_def by auto
+  then obtain \<tau>\<^sub>2 where 2: "(\<Gamma>,x:\<tau>'),y:\<tau>\<^sub>1 \<turnstile>\<^sub>t\<^sub>y e : \<tau>\<^sub>2" "\<tau> = (\<tau>\<^sub>1 \<rightarrow> \<tau>\<^sub>2)" using Abs(5) Ty_AbsE' by metis
   moreover have "(\<Gamma>,x:\<tau>'),y:\<tau>\<^sub>1 = (\<Gamma>,y:\<tau>\<^sub>1),x:\<tau>'" by blast
-  moreover have "x \<sharp> \<Gamma>,y:\<tau>\<^sub>1" using Abs(1,4) unfolding fresh_def by auto
-  ultimately have "\<Gamma>,y:\<tau>\<^sub>1 \<turnstile>\<^sub>t\<^sub>y tvsubst (tvVVr_tvsubst(x := v)) e : \<tau>\<^sub>2" using Abs(2,5) by metis
+  moreover have "x \<sharp> \<Gamma>,y:\<tau>\<^sub>1" using Abs(1,2,6) unfolding fresh_def by auto
+  ultimately have "\<Gamma>,y:\<tau>\<^sub>1 \<turnstile>\<^sub>t\<^sub>y tvsubst (tvVVr_tvsubst(x := v)) e : \<tau>\<^sub>2" using Abs(4,7) by metis
   moreover have "y \<sharp> \<Gamma>" using Abs(1) unfolding fresh_def by auto
   ultimately show ?case unfolding terms.subst(3)[OF SSupp_upd_VVr_bound 1] using Ty_Abs 2(2) by blast
 qed

--- a/STLC.thy
+++ b/STLC.thy
@@ -949,6 +949,10 @@ apply (rule iffD1[OF fun_cong[OF fun_cong [OF fset.rel_eq]]])
   done
 lemmas Ty_AbsE' = Ty_AbsE''[unfolded prod_sets_simps]
 
+context begin
+ML_file \<open>./Tools/binder_induction.ML\<close>
+end
+
 lemma context_invariance: "\<Gamma> \<turnstile>\<^sub>t\<^sub>y e : \<tau>' \<Longrightarrow> \<forall>x\<in>FFVars_terms e. \<forall>\<tau>. (x, \<tau>) |\<in>| \<Gamma> \<longrightarrow> (x, \<tau>) |\<in>| \<Gamma>' \<Longrightarrow> \<Gamma>' \<turnstile>\<^sub>t\<^sub>y e : \<tau>'"
 proof (binder_induction \<Gamma> e \<tau>' arbitrary: \<Gamma>' avoiding: \<Gamma>' rule: Ty_fresh_induct_param)
   case (Ty_Var x \<tau> \<Gamma> \<Gamma>')

--- a/Tools/binder_induction.ML
+++ b/Tools/binder_induction.ML
@@ -146,8 +146,8 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
           fun extract_vars var t =
             let
               val T = fastype_of t
-              fun extract_deep T t = if Term.is_TFree T then
-                (if T = var then (SOME t, []) else (NONE, []))
+              fun extract_deep T t = if T = var then (SOME t, []) else (
+                if Term.is_TFree var then (NONE, [])
               else case try HOLogic.dest_setT T of
                 SOME T => (NONE, if T = var then [t] else [])
                 | NONE =>
@@ -168,9 +168,10 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                     val t = case ts of
                       [] => NONE
                       | _ => SOME (foldl1 MRBNF_Util.mk_Un (map_filter I ts))
-                  in (t, flat ts') end;
+                  in (t, flat ts') end);
             in if T = var then (SOME (HOLogic.mk_set T [t]), []) else extract_deep T t end
 
+          val _ = @{print} vars
           val terms_rawss = map (fn var =>
             apfst (map_filter I) (apsnd flat (split_list (map (extract_vars var) avoiding)))
           ) vars;
@@ -417,7 +418,7 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                   Subgoal.FOCUS_PREMS (fn {context=ctxt, prems=inner_prems, ...} => EVERY1 [
                   K (print_tac ctxt "wat1"),
                   FIRST' (map (fn thm => resolve_tac ctxt (repeat_mp thm) THEN_ALL_NEW (FIRST' [
-                    resolve_tac ctxt inner_prems THEN_ALL_NEW K no_tac,
+                    resolve_tac ctxt (prems @ inner_prems) THEN_ALL_NEW K no_tac,
                     (* Extra higher order rules, no induction *)
                     EVERY' [
                       REPEAT_DETERM o rtac ctxt @{thm induct_impliesI},

--- a/Tools/binder_induction.ML
+++ b/Tools/binder_induction.ML
@@ -90,6 +90,7 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
         SOME rs => inst_rule (Rule_Cases.strict_mutual_rule ctxt rs)
       | NONE => error "Automatic detection of induction rule is not supported yet, please specify with rule:"
       );
+      val _ = @{print} ruleq
 
       fun dest_ordLess t =
         let val t' = case HOLogic.dest_mem t of
@@ -109,6 +110,8 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
       |> Seq.maps (Rule_Cases.consume defs_ctxt (flat defs) facts)
       |> Seq.map (fn (((cases, concls), (more_consumes, more_facts)), rule) =>
         let
+          val _ = @{print} concls
+          val _ = @{print} cases
           val concl = Thm.concl_of rule
           val P_vars = rev (Term.add_vars concl []);
           val prems = Thm.prems_of rule
@@ -172,7 +175,7 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
             apfst (map_filter I) (apsnd flat (split_list (map (extract_vars var) avoiding)))
           ) vars;
 
-          val goals = Logic.dest_conjunction_list (hd (Thm.prems_of st));
+          val goals = (if length concls > 1 then Logic.dest_conjunction_list else single) (hd (Thm.prems_of st));
           val goals' = map (Logic.list_implies o apfst (drop nmajor) o Logic.strip_horn) goals;
           val goals'' = map (fold_rev (curry Logic.mk_implies) (map Thm.prop_of more_facts)) goals';
 
@@ -187,6 +190,9 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
             let fun go (Const ("Pure.all", _) $ Abs (x, T, t)) xs = go t (Free (x, T)::xs)
                   | go t xs = (rev xs, subst_bounds (xs, t))
             in go t [] end
+          fun mk_induct_equal (t1, t2) =
+            let val T = fastype_of t1
+            in Const (@{const_name HOL.induct_equal}, T --> T --> @{typ bool}) $ t1 $ t2 end;
 
           val finsts' = map (map_filter I) insts;
           val cases' = map (fn rule =>
@@ -196,12 +202,12 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
               val rule = Term.subst_atomic (bvars ~~ bvars') rule;
               val (prems, outer_concl) = Logic.strip_horn rule;
               val (P_var, P_args) = apsnd (fst o split_last) (Term.strip_comb (HOLogic.dest_Trueprop outer_concl));
-              val (((finst', goal), idefs), arb) = the (AList.lookup (op=) (map Var P_vars ~~ (finsts' ~~ goals' ~~ defs ~~ arbitrary)) P_var);
+              val (((finst', goal), idefs), arb) = the (AList.lookup (op=) (map Var P_vars ~~ (finsts' ~~ goals'' ~~ defs ~~ arbitrary)) P_var);
 
               val subst_ind = finst' ~~ P_args;
               val raw_defs = map (Logic.dest_equals o Thm.prop_of) idefs;
               val eq_prems = map_filter (fn (inst, arg) =>
-                Option.map (fn def => mk_Trueprop_eq (arg, def)) (AList.lookup (op=) raw_defs inst)
+                Option.map (fn def => HOLogic.mk_Trueprop (mk_induct_equal (arg, def))) (AList.lookup (op=) raw_defs inst)
               ) subst_ind;
 
               val prems' = maps (fn prem =>
@@ -243,7 +249,7 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                           val subst = inst ~~ fst (split_last ts);
                           val raw_defs = map (Logic.dest_equals o Thm.prop_of) defs;
                           val eq_prems = map_filter (fn (inst, arg) =>
-                            Option.map (fn def => mk_Trueprop_eq (arg, def)) (AList.lookup (op=) raw_defs inst)
+                            Option.map (fn def => HOLogic.mk_Trueprop (mk_induct_equal (arg, def))) (AList.lookup (op=) raw_defs inst)
                           ) subst;
                         in (fold_rev (curry Logic.mk_implies) eq_prems (Term.subst_atomic subst goal), true, arbs) end
                       | NONE => (HOLogic.mk_Trueprop concl, false, []);
@@ -254,9 +260,7 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                 end
               ) prems;
             in fold_rev Logic.all (bvars' @ map Free arb) (
-              fold_rev (curry Logic.mk_implies) (
-                map (Term.subst_atomic subst_ind o Thm.prop_of) more_facts @ prems' @ eq_prems
-              ) (Term.subst_atomic subst_ind goal)
+              fold_rev (curry Logic.mk_implies) (prems' @ eq_prems) (Term.subst_atomic subst_ind goal)
             ) end
           ) cases_prems;
 
@@ -266,10 +270,12 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
             ) in fold_rev Logic.all (filter (fn t => Term.exists_subterm (fn t' => t = t') prem) avoiding_arbitraries) prem end
           ) raws) terms_rawss vars);
 
+          val mk_induct_conj = HOLogic.mk_binop @{const_name HOL.induct_conj}
           fun mk_induct_implies t1 t2 =
             Const (@{const_name HOL.induct_implies}, @{typ bool} --> @{typ bool} --> @{typ bool}) $ t1 $ t2;
+          val to_induct_implies = uncurry (fold_rev mk_induct_implies) o map_prod (map HOLogic.dest_Trueprop) HOLogic.dest_Trueprop o Logic.strip_horn
           val rule_t = fold_rev (curry Logic.mk_implies) (take nmajor prems @ bound_prems @ cases') (
-            Logic.mk_conjunction_list (map (HOLogic.mk_Trueprop o uncurry (fold_rev mk_induct_implies) o map_prod (map HOLogic.dest_Trueprop) HOLogic.dest_Trueprop o Logic.strip_horn) goals')
+            Logic.mk_conjunction_list (map (HOLogic.mk_Trueprop o foldr1 mk_induct_conj o map to_induct_implies o Logic.dest_conjunction_list) goals')
           );
 
           val avoiding_dynamics = avoiding_arbitraries @ map snd avoiding_inducts;
@@ -281,9 +287,9 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
             @{map 4} (fn goal => fn inst => fn arb => fn defs => Thm.cterm_of ctxt (
               fold_rev Term.absfree (map dest_Free inst) (Term.absfree (dest_Free rho) (
                 fold_rev mk_all arb (Induct.atomize_term ctxt (
-                  Logic.mk_implies (mk_Trueprop_eq (
+                  Logic.mk_implies (HOLogic.mk_Trueprop (mk_induct_equal (
                     avoiding_dynamic, rho
-                  ), fold_rev (curry Logic.mk_implies) (map Thm.prop_of defs) goal)
+                  )), fold_rev (curry Logic.mk_implies) (map Thm.prop_of defs) goal)
                 ))
               ))
             )) goals'' finsts' arbitrary defs
@@ -308,7 +314,7 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
             K (Local_Defs.unfold0_tac ctxt (flat defs @ @{thms atomize_conj HOL.induct_implies_def})),
             REPEAT_DETERM o eresolve_tac ctxt [allE, conjE],
             REPEAT_DETERM_N (length goals) o etac ctxt @{thm impE[OF _ refl]},
-            REPEAT_DETERM o etac ctxt @{thm impE[OF _ induct_equal_ref]},
+            REPEAT_DETERM o etac ctxt @{thm impE[OF _ induct_equal_refl]},
             REPEAT_DETERM o (etac ctxt impE THEN' assume_tac ctxt),
             REPEAT_DETERM o EVERY' [
               TRY o rtac ctxt conjI,
@@ -359,20 +365,38 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
             SOME thm' => repeat_OF thm thm'
             | NONE => thm2;
 
+          fun split_conjunction thm = case try (fn thm => (thm RS @{thm conjunctionD1}, thm RS @{thm conjunctionD2})) thm of
+            SOME (thms, thm) => split_conjunction thms @ [thm]
+            | NONE => [thm] (*if n = 1 then [thm]
+            else let val (thms, thm) = fold_map
+              (K (fn thm => )) (1 upto n - 1) thm
+            in thms @ [thm] end;*)
+
+          fun repeat_mp thm = case try (fn thm => thm RS @{thm induct_mp}) thm of
+            SOME thm' => thm :: repeat_mp thm'
+            | NONE => [thm]
+
+          val _ = @{print} (inst_rule RS inst_thm)
           val rule_thm = Goal.prove_sorry defs_ctxt [] [] rule_t (fn {context=ctxt, ...} => EVERY1 [
-            K (Local_Defs.unfold0_tac ctxt @{thms induct_implies_eq}),
+            K (Local_Defs.unfold0_tac ctxt @{thms induct_implies_eq induct_conj_eq}),
+            K (print_tac ctxt "foo"),
             Subgoal.FOCUS_PREMS (fn {context=ctxt, prems, ...} =>
-              let val prems' = map (Local_Defs.unfold0 ctxt @{thms induct_implies_eq[symmetric]}) prems
+              let
+                val ctxt' = ctxt;
+                val prems' = map (Local_Defs.unfold0 ctxt @{thms induct_implies_eq[symmetric]}) prems;
+                val prems' = maps split_conjunction prems';
+                val _ = @{print} prems
               in EVERY1 [
                 rtac ctxt (inst_rule RS inst_thm),
                 REPEAT_DETERM o resolve_tac ctxt prems,
                 K (Local_Defs.unfold0_tac ctxt @{thms case_prod_beta}),
                 (* boundness *)
-                REPEAT_DETERM o resolve_tac ctxt (bound_thms @ set_bds @
+                REPEAT_DETERM o resolve_tac ctxt (bound_thms @ set_bds @ prems @
                   @{thms allI finite_ordLess_infinite2[OF finite_singleton cinfinite_imp_infinite]
                     ordIso_ordLeq_trans[OF ordIso_symmetric[OF card_of_Field_ordIso]] emp_bound
                   }
                 ),
+                K (print_tac ctxt "foo1"),
                 REPEAT_DETERM o EVERY' [
                   TRY o EVERY' [
                     dtac ctxt @{thm iffD1[OF arg_cong[of _ _ Not], rotated]},
@@ -384,11 +408,33 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                     ],
                     REPEAT_DETERM o dtac ctxt @{thm iffD1[OF arg_cong[OF singleton_iff, of Not]]}
                   ],
-                  Subgoal.FOCUS_PREMS (fn {context=ctxt, prems=inner_prems, ...} => FIRST1 (map (fn p => EVERY' [
-                    REPEAT_DETERM o resolve_tac ctxt @{thms induct_impliesI allI},
-                    rtac ctxt p,
+                  REPEAT_DETERM o rtac ctxt allI,
+                  (*REPEAT_DETERM o EVERY' [ *)
+                    rtac ctxt @{thm induct_impliesI[of "HOL.induct_equal _ _"]},
+                    dtac ctxt @{thm iffD1[OF meta_eq_to_obj_eq[OF HOL.induct_equal_def]]},
+                (*  ], *)
+                  hyp_subst_tac ctxt,
+                  K (print_tac ctxt "wat1"),
+                  FIRST' (map (fn thm => resolve_tac ctxt (repeat_mp thm) THEN_ALL_NEW (EVERY' [
+                    REPEAT_DETERM o etac ctxt allE,
+                    REPEAT_DETERM o etac ctxt @{thm induct_impliesE[OF _ induct_equal_refl]},
+                    K (print_tac ctxt "wat2"),
+                    assume_tac ctxt
+                  ] ORELSE' EVERY' [
+                    SELECT_GOAL (print_tac ctxt "fail1"),
+                    assume_tac ctxt,
+                    SELECT_GOAL (print_tac ctxt "fail")
+                  ])) prems),
+                  K (print_tac ctxt "bar")
+                  (*Subgoal.FOCUS_PREMS (fn {context=ctxt, prems=inner_prems, ...} => FIRST1 (map (fn p => EVERY' [
+                    REPEAT_DETERM o rtac ctxt allI,
+                    rtac ctxt @{thm induct_impliesI},
+                    K (print_tac ctxt "1"),
+                    rtac ctxt (@{print}p),
                     K (Local_Defs.unfold0_tac ctxt @{thms induct_implies_eq[symmetric] atomize_all[symmetric] HOL.induct_equal_def}),
-                    REPEAT_DETERM o FIRST' [
+                    (* K (print_tac ctxt "2"), *)
+                    REPEAT_DETERM o (SELECT_GOAL (print_tac ctxt' "2") THEN' FIRST' [
+                      rtac ctxt @{thm conjunctionI},
                       (* prems from original induction theorem *)
                       resolve_tac ctxt inner_prems THEN_ALL_NEW (K no_tac),
                       (* higher order prems from original induction theorem *)
@@ -408,11 +454,13 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                       ]),
                       (* IHs *)
                       SELECT_GOAL (EVERY1 [
-                        eresolve_tac ctxt (map (Local_Defs.unfold0 ctxt @{thms HOL.induct_rulify atomize_eq} o repeat_OF @{thm spec}) inner_prems),
+                        eresolve_tac ctxt (@{print}(maps (split_conjunction o Local_Defs.unfold0 ctxt @{thms HOL.induct_rulify atomize_eq} o repeat_OF @{thm spec}) inner_prems)),
+                        K (print_tac ctxt "wat"),
                         REPEAT_DETERM o assume_tac ctxt
                       ]),
                       SELECT_GOAL (EVERY1 [
-                        resolve_tac ctxt (map (repeat_OF @{thm induct_mp} o repeat_OF @{thm spec}) inner_prems),
+                        resolve_tac ctxt (maps (split_conjunction o repeat_OF @{thm induct_mp} o repeat_OF @{thm spec}) inner_prems),
+                        K (print_tac ctxt "wat2"),
                         rtac ctxt refl,
                         REPEAT_DETERM o assume_tac ctxt
                       ]),
@@ -432,11 +480,14 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                         REPEAT_DETERM o etac ctxt conjE,
                         assume_tac ctxt
                       ])
-                    ],
+                    ]),
+                    K (print_tac ctxt "end"),
                     IF_UNSOLVED o K no_tac
-                  ]) prems')) ctxt
+                  ]) prems')) ctxt,
+                  K (print_tac ctxt "endend") *)
                 ],
-                rtac ctxt refl,
+                K (print_tac ctxt "foo"),
+                rtac ctxt @{thm induct_equal_refl},
                 REPEAT_DETERM o resolve_tac ctxt more_facts
               ] end
             ) ctxt

--- a/Tools/binder_induction.ML
+++ b/Tools/binder_induction.ML
@@ -99,11 +99,11 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
       fun dest_card_of (Const (@{const_name card_of}, _) $ t) = t
         | dest_card_of t = raise TERM ("dest_card_of", [t])
 
-      val rule = snd ruleq;
-
-      fun strip_all (Const (@{const_name All}, _) $ t) = (case t of
-        Abs (_, _, t) => strip_all t | _ => strip_all t)
-        | strip_all t = t
+      fun strip_all (Const (@{const_name HOL.All}, _) $ t) = (case t of
+        Abs (x, T, t) => let val a = Free (x, T)
+          in apfst (curry (op::) a) (strip_all (Term.subst_bound (a, t))) end
+          | _ => strip_all t)
+        | strip_all t = ([], t)
 
     fun context_tac _ _ = Seq.single ruleq
       |> Seq.maps (Rule_Cases.consume defs_ctxt (flat defs) facts)
@@ -114,20 +114,19 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
           val prems = Thm.prems_of rule
           val prem_concls = map Logic.strip_assums_concl prems;
 
-          val vars = map_filter (try (
+          val vars_prems = map (try (
             HOLogic.dest_Trueprop
-            #> strip_all
+            #> snd o strip_all
             #> fst o dest_ordLess
             #> dest_card_of
             #> fst o Term.strip_comb
             #> snd o Term.dest_Var
             #> HOLogic.dest_setT o range_type
           )) prem_concls;
+          val ((nmajor, vars), nind_cases) = vars_prems
+            |> apfst length o chop_prefix (not o Option.isSome)
+            ||>> map_prod (map the) length o chop_prefix Option.isSome
           val nvars = length vars;
-
-          val nind_cases = length (filter (
-            Term.exists_subterm (member (op=) (map Var P_vars))
-          ) (drop nvars prem_concls));
 
           val finsts = map_filter I (flat insts);
           val avoiding_arbitraries = distinct (op=) (filter (fn arb =>
@@ -170,15 +169,16 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
           ) vars;
 
           val goals = Logic.dest_conjunction_list (hd (Thm.prems_of st));
+          val goals' = map (Logic.list_implies o apfst (drop nmajor) o Logic.strip_horn) goals;
 
-          val cases_prems = drop nvars prems;
+          val cases_prems = drop (nmajor + nvars) prems;
           val K_vars = rev (distinct (op=) (filter (fn (_, T) =>
             case try (HOLogic.dest_setT o range_type) T of
               NONE => false
               | SOME T => member (op=) vars T
           ) (fold_rev Term.add_vars cases_prems [])));
 
-          fun strip_all t =
+          fun strip_pure_all t =
             let fun go (Const ("Pure.all", _) $ Abs (x, T, t)) xs = go t (Free (x, T)::xs)
                   | go t xs = (rev xs, subst_bounds (xs, t))
             in go t [] end
@@ -186,16 +186,21 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
           val finsts' = map (map_filter I) insts;
           val cases' = map (fn rule =>
             let
-              val ((bvars, rho), rule) = apfst split_last (strip_all rule)
+              val ((bvars, rho), rule) = apfst split_last (strip_pure_all rule)
+              val bvars' = rev (map Free (fold Term.rename_wrt_term goals' (map dest_Free bvars)));
+              val rule = Term.subst_atomic (bvars ~~ bvars') rule;
               val (prems, outer_concl) = Logic.strip_horn rule;
               val (P_var, P_args) = apsnd (fst o split_last) (Term.strip_comb (HOLogic.dest_Trueprop outer_concl));
-              val ((finst', goal), arb) = the (AList.lookup (op=) (map Var P_vars ~~ (finsts' ~~ goals ~~ arbitrary)) P_var);
+              val ((finst', goal), arb) = the (AList.lookup (op=) (map Var P_vars ~~ (finsts' ~~ goals' ~~ arbitrary)) P_var);
               val subst_ind = finst' ~~ P_args;
 
               val prems' = maps (fn prem =>
                 let
-                  val (lvars, prem) = strip_all prem;
+                  val (lvars, prem) = strip_pure_all prem;
                   val (prems, concl) = apsnd HOLogic.dest_Trueprop (Logic.strip_horn prem);
+                  val (lvars, concl) = case strip_all concl of
+                    ([x], t) => if x = rho then (lvars @ [x], t) else (lvars, concl)
+                    | _ => (lvars, concl);
                 in if Term.exists_subterm (member (op=) (map Var K_vars)) concl then
                   let
                     val (z, (K_var, rho)) = apsnd Term.dest_comb (HOLogic.dest_mem (HOLogic.dest_not concl));
@@ -222,7 +227,7 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                 else
                   let
                     val (t, ts) = Term.strip_comb concl;
-                    val (concl', strip, arbs) = case AList.lookup (op=) (map Var P_vars ~~ (goals ~~ finsts' ~~ arbitrary)) t of
+                    val (concl', strip, arbs) = case AList.lookup (op=) (map Var P_vars ~~ (goals' ~~ finsts' ~~ arbitrary)) t of
                       SOME ((goal, inst), arbs) => (Term.subst_atomic (inst ~~ fst (split_last ts)) goal, true, arbs)
                       | NONE => (HOLogic.mk_Trueprop concl, false, []);
                     val prem' = fold_rev Logic.all ((if strip then fst (split_last lvars) else lvars) @ map Free arbs) (
@@ -231,7 +236,7 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                   in [prem'] end
                 end
               ) prems;
-            in fold_rev Logic.all (bvars @ map Free arb) (
+            in fold_rev Logic.all (bvars' @ map Free arb) (
               fold_rev (curry Logic.mk_implies) prems' (Term.subst_atomic subst_ind goal)
             ) end
           ) cases_prems;
@@ -240,8 +245,10 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
             MRBNF_Util.mk_ordLess (MRBNF_Util.mk_card_of raw) (MRBNF_Util.mk_card_of (HOLogic.mk_UNIV var))
           )) raws) terms_rawss vars);
 
-          val rule_t = fold_rev (curry Logic.mk_implies) (bound_prems @ cases') (
-            Logic.mk_conjunction_list goals
+          fun mk_induct_implies t1 t2 =
+            Const (@{const_name HOL.induct_implies}, @{typ bool} --> @{typ bool} --> @{typ bool}) $ t1 $ t2;
+          val rule_t = fold_rev (curry Logic.mk_implies) (take nmajor prems @ bound_prems @ cases') (
+            Logic.mk_conjunction_list (map (HOLogic.mk_Trueprop o uncurry (fold_rev mk_induct_implies) o map_prod (map HOLogic.dest_Trueprop) HOLogic.dest_Trueprop o Logic.strip_horn) goals')
           );
 
           val avoiding_dynamics = avoiding_arbitraries @ map snd avoiding_inducts;
@@ -258,7 +265,7 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                   ), goal)
                 ))
               ))
-            )) goals finsts' arbitrary
+            )) goals' finsts' arbitrary
           ) rule;
 
           val inst_concl = Thm.concl_of inst_rule;
@@ -317,51 +324,88 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
 
           val set_bds = map (fn thm => @{thm ordLess_ordLeq_trans} OF [thm]) (get_set_bd (map fastype_of avoiding));
 
+          fun resolve_rule_tac ctxt thms =
+            let val tacs = map (fn thm => etac ctxt thm THEN_ALL_NEW assume_tac ctxt) thms
+            in fold_rev (curry op APPEND') tacs (K no_tac) end
+
+          fun repeat_OF thm thm2 = case try (curry (op OF) thm) [thm2] of
+            SOME thm' => repeat_OF thm thm'
+            | NONE => thm2;
+
           val rule_thm = Goal.prove_sorry ctxt [] [] rule_t (fn {context=ctxt, ...} => EVERY1 [
-            REPEAT_DETERM o EqSubst.eqsubst_tac ctxt [0] @{thms induct_implies_eq},
-            Subgoal.FOCUS_PREMS (fn {context=ctxt, prems, ...} => EVERY1 [
-              rtac ctxt (inst_rule RS inst_thm),
-              K (Local_Defs.unfold0_tac ctxt @{thms case_prod_beta}),
-              (* boundness *)
-              REPEAT_DETERM o resolve_tac ctxt (bound_thms @ prems @ set_bds @
-                @{thms finite_ordLess_infinite2[OF finite_singleton cinfinite_imp_infinite]
-                  ordIso_ordLeq_trans[OF ordIso_symmetric[OF card_of_Field_ordIso]] emp_bound
-                }
-              ),
-              K (Local_Defs.unfold0_tac ctxt @{thms HOL.induct_implies_def}),
-              REPEAT_DETERM o Subgoal.FOCUS_PREMS (fn {context=ctxt, prems=inner_prems, ...} => EVERY1 [
-                REPEAT_DETERM o resolve_tac ctxt [allI, impI],
-                resolve_tac ctxt prems,
-                REPEAT_DETERM o FIRST' [
-                  EVERY' [
-                    Method.insert_tac ctxt inner_prems,
-                    Goal.assume_rule_tac ctxt
-                  ],
-                  EVERY' [
-                    dresolve_tac ctxt inner_prems,
-                    REPEAT_DETERM o etac ctxt allE,
-                    etac ctxt impE,
+            K (Local_Defs.unfold0_tac ctxt @{thms induct_implies_eq}),
+            Subgoal.FOCUS_PREMS (fn {context=ctxt, prems, ...} =>
+              let val prems' = map (Local_Defs.unfold0 ctxt @{thms induct_implies_eq[symmetric]}) prems
+              in EVERY1 [
+                rtac ctxt (inst_rule RS inst_thm),
+                REPEAT_DETERM o resolve_tac ctxt prems,
+                K (Local_Defs.unfold0_tac ctxt @{thms case_prod_beta}),
+                (* boundness *)
+                REPEAT_DETERM o resolve_tac ctxt (bound_thms @ set_bds @
+                  @{thms allI finite_ordLess_infinite2[OF finite_singleton cinfinite_imp_infinite]
+                    ordIso_ordLeq_trans[OF ordIso_symmetric[OF card_of_Field_ordIso]] emp_bound
+                  }
+                ),
+                REPEAT_DETERM o EVERY' [
+                  TRY o EVERY' [
+                    dtac ctxt @{thm iffD1[OF arg_cong[of _ _ Not], rotated]},
+                    SELECT_GOAL (Local_Defs.unfold0_tac ctxt @{thms Un_iff}),
                     rtac ctxt refl,
-                    REPEAT_DETERM o (etac ctxt impE THEN' assume_tac ctxt),
-                    assume_tac ctxt
+                    REPEAT_DETERM o EVERY' [
+                      dtac ctxt @{thm iffD1[OF de_Morgan_disj]},
+                      etac ctxt conjE
+                    ],
+                    REPEAT_DETERM o dtac ctxt @{thm iffD1[OF arg_cong[OF singleton_iff, of Not]]}
                   ],
-                  EVERY' [
-                    TRY o (rtac ctxt @{thm iffD1[OF disjoint_single]} THEN' rtac ctxt @{thm trans[OF Int_commute]}),
-                    rtac ctxt @{thm iffD2[OF disjoint_iff]},
-                    rtac ctxt allI,
-                    rtac ctxt impI,
-                    dresolve_tac ctxt inner_prems,
-                    hyp_subst_tac ctxt,
-                    SELECT_GOAL (Local_Defs.unfold0_tac ctxt @{thms fst_conv snd_conv Un_iff de_Morgan_disj}),
-                    REPEAT_DETERM o etac ctxt conjE,
-                    assume_tac ctxt
-                  ],
-                  assume_tac ctxt,
-                  resolve_tac ctxt inner_prems
-                ]
-              ]) ctxt,
-              rtac ctxt refl
-            ]) ctxt
+                  Subgoal.FOCUS_PREMS (fn {context=ctxt, prems=inner_prems, ...} => EVERY1 [
+                    REPEAT_DETERM o resolve_tac ctxt @{thms induct_impliesI allI},
+                    resolve_tac ctxt prems',
+                    K (Local_Defs.unfold0_tac ctxt @{thms induct_implies_eq[symmetric] atomize_all[symmetric]}),
+                    REPEAT_DETERM o FIRST' [
+                      assume_tac ctxt,
+                      (* prems from original induction theorem *)
+                      resolve_tac ctxt inner_prems THEN_ALL_NEW (K no_tac),
+                      (* higher order prems from original induction theorem *)
+                      resolve_rule_tac ctxt inner_prems,
+                      (* higher order IHs *)
+                      SELECT_GOAL (EVERY1 [
+                        dresolve_tac ctxt inner_prems,
+                        REPEAT_DETERM o etac ctxt allE,
+                        etac ctxt @{thm induct_impliesE[OF _ refl]},
+                        REPEAT_DETERM o EVERY' [
+                          etac ctxt @{thm induct_impliesE},
+                          assume_tac ctxt
+                        ],
+                        assume_tac ctxt
+                      ]),
+                      (* IHs *)
+                      SELECT_GOAL (EVERY1 [
+                        resolve_tac ctxt (map (repeat_OF @{thm induct_mp} o repeat_OF @{thm spec}) inner_prems),
+                        rtac ctxt refl,
+                        REPEAT_DETERM o assume_tac ctxt
+                      ]),
+                      (* freshness *)
+                      EVERY' [
+                        hyp_subst_tac ctxt,
+                        resolve_tac ctxt inner_prems THEN_ALL_NEW (K no_tac)
+                      ],
+                      SELECT_GOAL (EVERY1 [
+                        TRY o (rtac ctxt @{thm iffD1[OF disjoint_single]} THEN' rtac ctxt @{thm trans[OF Int_commute]}),
+                        rtac ctxt @{thm iffD2[OF disjoint_iff]},
+                        rtac ctxt allI,
+                        rtac ctxt impI,
+                        dresolve_tac ctxt inner_prems,
+                        hyp_subst_tac ctxt,
+                        SELECT_GOAL (Local_Defs.unfold0_tac ctxt @{thms fst_conv snd_conv Un_iff de_Morgan_disj}),
+                        REPEAT_DETERM o etac ctxt conjE,
+                        assume_tac ctxt
+                      ])
+                    ]
+                  ]) ctxt
+                ],
+                rtac ctxt refl
+              ] end
+            ) ctxt
           ]);
 
           val rule_thm = Local_Defs.unfold0 ctxt @{thms MRBNF_Recursor.prod_sets_simps} rule_thm;
@@ -373,25 +417,10 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
         in (((new_cases @ drop nvars cases, concls), (more_consumes, more_facts)), rule_thm) end
       )
     |> Seq.maps (fn (((cases, concls), (more_consumes, more_facts)), rule) =>
-          (PRECISE_CONJUNCTS (length concls) (ALLGOALS (fn j =>
-            (CONJUNCTS (ALLGOALS
-              let
-                val adefs = nth_list atomized_defs (j - 1);
-                val frees = fold (Term.add_frees o Thm.prop_of) adefs [];
-                val xs = [];
-                val k = nth concls (j - 1) + more_consumes;
-              in
-                Method.insert_tac defs_ctxt (more_facts @ adefs) THEN'
-                  (if simp then
-                     Induct.rotate_tac k (length adefs) THEN'
-                     Induct.arbitrary_tac defs_ctxt k (List.partition (member op = frees) xs |> op @)
-                   else
-                     Induct.arbitrary_tac defs_ctxt k xs)
-               end)
-            THEN' Induct.inner_atomize_tac defs_ctxt) j))
+          (PRECISE_CONJUNCTS (length concls) (ALLGOALS (Induct.inner_atomize_tac defs_ctxt))
           THEN' Induct.atomize_tac defs_ctxt) i st
         |> Seq.maps (fn st' =>
-              Induct.guess_instance ctxt (Induct.internalize ctxt more_consumes rule) i st'
+          Induct.guess_instance ctxt (Induct.internalize ctxt more_consumes rule) i st'
               |> Seq.map (rule_instance ctxt (burrow_options (Variable.polymorphic ctxt) taking))
               |> Seq.maps (fn rule' =>
                 CONTEXT_CASES (rule_cases ctxt rule' cases)

--- a/Tools/binder_induction.ML
+++ b/Tools/binder_induction.ML
@@ -147,7 +147,6 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                 | NONE =>
                   let
                     val (name, Ts) = Term.dest_Type T
-                    (* TODO: special case sets for prod *)
                     val sets = case MRBNF_Def.mrbnf_of ctxt name of
                       SOME mrbnf => MRBNF_Def.sets_of_mrbnf mrbnf
                       | NONE => (case BNF_Def.bnf_of ctxt name of
@@ -365,6 +364,7 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
             ]) ctxt
           ]);
 
+          val rule_thm = Local_Defs.unfold0 ctxt @{thms MRBNF_Recursor.prod_sets_simps} rule_thm;
           val names = map (fst o dest_Free) (
             fst (BNF_Util.mk_Frees "Bound" (map (K HOLogic.unitT) bound_prems) ctxt)
           );

--- a/Tools/binder_induction.ML
+++ b/Tools/binder_induction.ML
@@ -114,6 +114,9 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
           val prems = Thm.prems_of rule
           val prem_concls = map Logic.strip_assums_concl prems;
 
+          val _ = @{print} rule
+          val _ = @{print} more_facts
+
           val vars_prems = map (try (
             HOLogic.dest_Trueprop
             #> snd o strip_all
@@ -135,6 +138,7 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
           val avoiding_inducts = filter (fn (_, ind) =>
               exists (Term.exists_subterm (curry (op=) ind)) avoiding
           ) (0 upto length finsts - 1 ~~ finsts);
+          val arbitrary = if length arbitrary = 0 then replicate (length P_vars) [] else arbitrary;
 
           fun extract_vars var t =
             let
@@ -170,6 +174,7 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
 
           val goals = Logic.dest_conjunction_list (hd (Thm.prems_of st));
           val goals' = map (Logic.list_implies o apfst (drop nmajor) o Logic.strip_horn) goals;
+          val goals'' = map (fold_rev (curry Logic.mk_implies) (map Thm.prop_of more_facts)) goals';
 
           val cases_prems = drop (nmajor + nvars) prems;
           val K_vars = rev (distinct (op=) (filter (fn (_, T) =>
@@ -187,12 +192,17 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
           val cases' = map (fn rule =>
             let
               val ((bvars, rho), rule) = apfst split_last (strip_pure_all rule)
-              val bvars' = rev (map Free (fold Term.rename_wrt_term goals' (map dest_Free bvars)));
+              val bvars' = rev (map Free (fold Term.rename_wrt_term goals'' (map dest_Free bvars)));
               val rule = Term.subst_atomic (bvars ~~ bvars') rule;
               val (prems, outer_concl) = Logic.strip_horn rule;
               val (P_var, P_args) = apsnd (fst o split_last) (Term.strip_comb (HOLogic.dest_Trueprop outer_concl));
-              val ((finst', goal), arb) = the (AList.lookup (op=) (map Var P_vars ~~ (finsts' ~~ goals' ~~ arbitrary)) P_var);
+              val (((finst', goal), idefs), arb) = the (AList.lookup (op=) (map Var P_vars ~~ (finsts' ~~ goals' ~~ defs ~~ arbitrary)) P_var);
+
               val subst_ind = finst' ~~ P_args;
+              val raw_defs = map (Logic.dest_equals o Thm.prop_of) idefs;
+              val eq_prems = map_filter (fn (inst, arg) =>
+                Option.map (fn def => mk_Trueprop_eq (arg, def)) (AList.lookup (op=) raw_defs inst)
+              ) subst_ind;
 
               val prems' = maps (fn prem =>
                 let
@@ -227,8 +237,15 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                 else
                   let
                     val (t, ts) = Term.strip_comb concl;
-                    val (concl', strip, arbs) = case AList.lookup (op=) (map Var P_vars ~~ (goals' ~~ finsts' ~~ arbitrary)) t of
-                      SOME ((goal, inst), arbs) => (Term.subst_atomic (inst ~~ fst (split_last ts)) goal, true, arbs)
+                    val (concl', strip, arbs) = case AList.lookup (op=) (map Var P_vars ~~ (goals'' ~~ finsts' ~~ defs ~~ arbitrary)) t of
+                      SOME (((goal, inst), defs), arbs) =>
+                        let
+                          val subst = inst ~~ fst (split_last ts);
+                          val raw_defs = map (Logic.dest_equals o Thm.prop_of) defs;
+                          val eq_prems = map_filter (fn (inst, arg) =>
+                            Option.map (fn def => mk_Trueprop_eq (arg, def)) (AList.lookup (op=) raw_defs inst)
+                          ) subst;
+                        in (fold_rev (curry Logic.mk_implies) eq_prems (Term.subst_atomic subst goal), true, arbs) end
                       | NONE => (HOLogic.mk_Trueprop concl, false, []);
                     val prem' = fold_rev Logic.all ((if strip then fst (split_last lvars) else lvars) @ map Free arbs) (
                       fold_rev (curry Logic.mk_implies) prems concl'
@@ -237,13 +254,17 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                 end
               ) prems;
             in fold_rev Logic.all (bvars' @ map Free arb) (
-              fold_rev (curry Logic.mk_implies) prems' (Term.subst_atomic subst_ind goal)
+              fold_rev (curry Logic.mk_implies) (
+                map (Term.subst_atomic subst_ind o Thm.prop_of) more_facts @ prems' @ eq_prems
+              ) (Term.subst_atomic subst_ind goal)
             ) end
           ) cases_prems;
 
-          val bound_prems = flat (map2 (fn (_, raws) => fn var => map (fn raw => HOLogic.mk_Trueprop (
-            MRBNF_Util.mk_ordLess (MRBNF_Util.mk_card_of raw) (MRBNF_Util.mk_card_of (HOLogic.mk_UNIV var))
-          )) raws) terms_rawss vars);
+          val bound_prems = flat (map2 (fn (_, raws) => fn var => map (fn raw =>
+            let val prem = HOLogic.mk_Trueprop (
+              MRBNF_Util.mk_ordLess (MRBNF_Util.mk_card_of raw) (MRBNF_Util.mk_card_of (HOLogic.mk_UNIV var))
+            ) in fold_rev Logic.all (filter (fn t => Term.exists_subterm (fn t' => t = t') prem) avoiding_arbitraries) prem end
+          ) raws) terms_rawss vars);
 
           fun mk_induct_implies t1 t2 =
             Const (@{const_name HOL.induct_implies}, @{typ bool} --> @{typ bool} --> @{typ bool}) $ t1 $ t2;
@@ -257,15 +278,15 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
           fun mk_all (a, b) c = HOLogic.mk_all (a, b, c)
           val rho = Free ("\<rho>", fastype_of avoiding_dynamic);
           val inst_rule = infer_instantiate ctxt (map fst P_vars ~~
-            @{map 3} (fn goal => fn inst => fn arb => Thm.cterm_of ctxt (
+            @{map 4} (fn goal => fn inst => fn arb => fn defs => Thm.cterm_of ctxt (
               fold_rev Term.absfree (map dest_Free inst) (Term.absfree (dest_Free rho) (
                 fold_rev mk_all arb (Induct.atomize_term ctxt (
                   Logic.mk_implies (mk_Trueprop_eq (
                     avoiding_dynamic, rho
-                  ), goal)
+                  ), fold_rev (curry Logic.mk_implies) (map Thm.prop_of defs) goal)
                 ))
               ))
-            )) goals' finsts' arbitrary
+            )) goals'' finsts' arbitrary defs
           ) rule;
 
           val inst_concl = Thm.concl_of inst_rule;
@@ -273,17 +294,22 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
           fun dest_induct_imp (Const (@{const_name HOL.induct_implies}, _) $ t1 $ t2) = (t2, t1)
 
           fun to_pure_all (Const ("HOL.All", _) $ Abs (a, b, t)) = to_pure_all (subst_bound (Free (a, b), t))
-            | to_pure_all t = apfst HOLogic.mk_Trueprop (dest_induct_imp t)
-          val (inst_concls', rho_imp) = split_list (map (to_pure_all o HOLogic.dest_Trueprop) inst_concls);
+            | to_pure_all t = dest_induct_imp t
+          val (inst_concls', rho_imps) = split_list (map (to_pure_all o HOLogic.dest_Trueprop) inst_concls);
+          val (def_conclss, inst_concls') = split_list (map2 (fn defs =>
+            apsnd HOLogic.mk_Trueprop o fold_map (K (swap o dest_induct_imp)) (0 upto length defs - 1 + length more_facts)
+          ) defs inst_concls');
 
           val inst_concl' = Logic.mk_implies (inst_concl, Logic.mk_implies (
-            HOLogic.mk_Trueprop (hd rho_imp),
-            Logic.mk_conjunction_list inst_concls'
+            HOLogic.mk_Trueprop (hd rho_imps),
+            fold_rev (curry Logic.mk_implies) (map Thm.prop_of more_facts) (Logic.mk_conjunction_list inst_concls')
           ));
-          val inst_thm = Goal.prove_sorry ctxt [fst (dest_Free rho)] [] inst_concl' (fn {context=ctxt, ...} => EVERY1 [
-            K (Local_Defs.unfold0_tac ctxt @{thms atomize_conj HOL.induct_implies_def}),
+          val inst_thm = Goal.prove_sorry defs_ctxt [fst (dest_Free rho)] [] inst_concl' (fn {context=ctxt, ...} => EVERY1 [
+            K (Local_Defs.unfold0_tac ctxt (flat defs @ @{thms atomize_conj HOL.induct_implies_def})),
             REPEAT_DETERM o eresolve_tac ctxt [allE, conjE],
             REPEAT_DETERM_N (length goals) o etac ctxt @{thm impE[OF _ refl]},
+            REPEAT_DETERM o etac ctxt @{thm impE[OF _ induct_equal_ref]},
+            REPEAT_DETERM o (etac ctxt impE THEN' assume_tac ctxt),
             REPEAT_DETERM o EVERY' [
               TRY o rtac ctxt conjI,
               assume_tac ctxt
@@ -291,12 +317,13 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
           ]);
           val inst_rule = infer_instantiate ctxt (map fst K_vars ~~
             map2 (fn (terms, raws) => fn var => Thm.cterm_of ctxt (
-              MRBNF_Util.mk_case_tuple (map dest_Free avoiding_dynamics) (
+              (if length avoiding_dynamics = 0 then Term.abs ("_", @{typ unit}) else I)
+              (MRBNF_Util.mk_case_tuple (map dest_Free avoiding_dynamics) (
                 let val ts = terms @ raws
                 in if length ts = 0 then
                   MRBNF_Util.mk_bot var
                 else foldl1 MRBNF_Util.mk_Un ts end
-              )
+              ))
             )) terms_rawss vars
           ) inst_rule;
 
@@ -332,7 +359,7 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
             SOME thm' => repeat_OF thm thm'
             | NONE => thm2;
 
-          val rule_thm = Goal.prove_sorry ctxt [] [] rule_t (fn {context=ctxt, ...} => EVERY1 [
+          val rule_thm = Goal.prove_sorry defs_ctxt [] [] rule_t (fn {context=ctxt, ...} => EVERY1 [
             K (Local_Defs.unfold0_tac ctxt @{thms induct_implies_eq}),
             Subgoal.FOCUS_PREMS (fn {context=ctxt, prems, ...} =>
               let val prems' = map (Local_Defs.unfold0 ctxt @{thms induct_implies_eq[symmetric]}) prems
@@ -357,16 +384,17 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                     ],
                     REPEAT_DETERM o dtac ctxt @{thm iffD1[OF arg_cong[OF singleton_iff, of Not]]}
                   ],
-                  Subgoal.FOCUS_PREMS (fn {context=ctxt, prems=inner_prems, ...} => EVERY1 [
+                  Subgoal.FOCUS_PREMS (fn {context=ctxt, prems=inner_prems, ...} => FIRST1 (map (fn p => EVERY' [
                     REPEAT_DETERM o resolve_tac ctxt @{thms induct_impliesI allI},
-                    resolve_tac ctxt prems',
-                    K (Local_Defs.unfold0_tac ctxt @{thms induct_implies_eq[symmetric] atomize_all[symmetric]}),
+                    rtac ctxt p,
+                    K (Local_Defs.unfold0_tac ctxt @{thms induct_implies_eq[symmetric] atomize_all[symmetric] HOL.induct_equal_def}),
                     REPEAT_DETERM o FIRST' [
-                      assume_tac ctxt,
                       (* prems from original induction theorem *)
                       resolve_tac ctxt inner_prems THEN_ALL_NEW (K no_tac),
                       (* higher order prems from original induction theorem *)
                       resolve_rule_tac ctxt inner_prems,
+
+                      assume_tac ctxt,
                       (* higher order IHs *)
                       SELECT_GOAL (EVERY1 [
                         dresolve_tac ctxt inner_prems,
@@ -379,6 +407,10 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                         assume_tac ctxt
                       ]),
                       (* IHs *)
+                      SELECT_GOAL (EVERY1 [
+                        eresolve_tac ctxt (map (Local_Defs.unfold0 ctxt @{thms HOL.induct_rulify atomize_eq} o repeat_OF @{thm spec}) inner_prems),
+                        REPEAT_DETERM o assume_tac ctxt
+                      ]),
                       SELECT_GOAL (EVERY1 [
                         resolve_tac ctxt (map (repeat_OF @{thm induct_mp} o repeat_OF @{thm spec}) inner_prems),
                         rtac ctxt refl,
@@ -400,10 +432,12 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                         REPEAT_DETERM o etac ctxt conjE,
                         assume_tac ctxt
                       ])
-                    ]
-                  ]) ctxt
+                    ],
+                    IF_UNSOLVED o K no_tac
+                  ]) prems')) ctxt
                 ],
-                rtac ctxt refl
+                rtac ctxt refl,
+                REPEAT_DETERM o resolve_tac ctxt more_facts
               ] end
             ) ctxt
           ]);
@@ -417,14 +451,14 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
         in (((new_cases @ drop nvars cases, concls), (more_consumes, more_facts)), rule_thm) end
       )
     |> Seq.maps (fn (((cases, concls), (more_consumes, more_facts)), rule) =>
-          (PRECISE_CONJUNCTS (length concls) (ALLGOALS (Induct.inner_atomize_tac defs_ctxt))
-          THEN' Induct.atomize_tac defs_ctxt) i st
+        Induct.atomize_tac defs_ctxt i st
+        |> Seq.map @{print}
         |> Seq.maps (fn st' =>
-          Induct.guess_instance ctxt (Induct.internalize ctxt more_consumes rule) i st'
-              |> Seq.map (rule_instance ctxt (burrow_options (Variable.polymorphic ctxt) taking))
+          Induct.guess_instance ctxt (@{print}(Induct.internalize ctxt (@{print}more_consumes) rule)) i (@{print}st')
+              |> Seq.map (fn x => (@{print} "foo"; x))
               |> Seq.maps (fn rule' =>
                 CONTEXT_CASES (rule_cases ctxt rule' cases)
-                  (resolve_tac ctxt [rule'] i THEN
+                  (resolve_tac defs_ctxt [rule'] i THEN
                     PRIMITIVE (singleton (Proof_Context.export defs_ctxt ctxt))) (ctxt, st'))))
     in (context_tac CONTEXT_THEN_ALL_NEW
         ((if simp then Induct.simplify_tac ctxt THEN' (TRY o Induct.trivial_tac ctxt) else K all_tac)

--- a/Tools/binder_induction.ML
+++ b/Tools/binder_induction.ML
@@ -1,6 +1,8 @@
 structure Binder_Induction =
 struct
 
+open BNF_Util
+
 fun unless_more_args scan = Scan.unless (Scan.lift
   ((Args.$$$ "arbitrary" || Args.$$$ "taking" || Args.$$$ "avoiding" || Args.$$$ "rule") -- Args.colon)) scan;
 
@@ -13,7 +15,7 @@ val arbitrary = Scan.optional (Scan.lift (Args.$$$ "arbitrary" -- Args.colon) |-
   Parse.and_list1' (Scan.repeat (unless_more_args free))) [];
 
 val avoiding = Scan.optional (Scan.lift (Args.$$$ "avoiding" -- Args.colon) |--
-  Parse.and_list1' (Scan.repeat (unless_more_args Args.term))) [];
+  Scan.repeat (unless_more_args Args.term)) [];
 
 val taking = Scan.optional (Scan.lift (Args.$$$ "taking" -- Args.colon) |--
   Scan.repeat1 (unless_more_args inst)) [];
@@ -75,18 +77,6 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
       val ((insts, defs), defs_ctxt) = fold_map Induct.add_defs def_insts ctxt |>> split_list;
       val atomized_defs = map (map (Conv.fconv_rule (Induct.atomize_cterm defs_ctxt))) defs;
 
-      val vars = distinct (op= o apply2 fst) (flat (map_filter (Option.mapPartial (fn t => Option.mapPartial (fn (name, Ts) =>
-        Option.map (fn mrbnf =>
-          let
-            val vars = MRBNF_Def.var_types_of_mrbnf mrbnf ~~ Ts;
-          in map_filter (fn (x, T) =>
-            if x = MRBNF_Def.Free_Var orelse x = MRBNF_Def.Bound_Var then SOME (T, mrbnf) else NONE
-          ) vars end
-      ) (MRBNF_Def.mrbnf_of ctxt name)) (try dest_Type (fastype_of t)))) (hd insts)));
-      val (var, mrbnf) = case vars of
-        [x] => x
-      | _ => error "Induction on datatypes with more than one variable is not supported yet";
-
       fun inst_rule (concls, r) =
         (if null insts then `Rule_Cases.get r
          else (align_left "Rule has fewer conclusions than arguments given"
@@ -97,129 +87,217 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
         |> (fn ((cases, consumes), th) => (((cases, concls), consumes), th));
 
       val ruleq = (case opt_rule of
-        SOME rs => Seq.single (inst_rule (Rule_Cases.strict_mutual_rule ctxt rs))
+        SOME rs => inst_rule (Rule_Cases.strict_mutual_rule ctxt rs)
       | NONE => error "Automatic detection of induction rule is not supported yet, please specify with rule:"
       );
-    fun context_tac _ _ = ruleq
+
+      fun dest_ordLess t =
+        let val t' = case HOLogic.dest_mem t of
+          (t', Const (@{const_name ordLess}, _)) => t'
+          | _ => raise TERM ("dest_ordLess", [t])
+        in HOLogic.dest_prod t' end
+      fun dest_card_of (Const (@{const_name card_of}, _) $ t) = t
+        | dest_card_of t = raise TERM ("dest_card_of", [t])
+
+      val rule = snd ruleq;
+
+      fun strip_all (Const (@{const_name All}, _) $ t) = (case t of
+        Abs (_, _, t) => strip_all t | _ => strip_all t)
+        | strip_all t = t
+
+    fun context_tac _ _ = Seq.single ruleq
       |> Seq.maps (Rule_Cases.consume defs_ctxt (flat defs) facts)
       |> Seq.map (fn (((cases, concls), (more_consumes, more_facts)), rule) =>
         let
+          val concl = Thm.concl_of rule
+          val P_vars = rev (Term.add_vars concl []);
+          val prems = Thm.prems_of rule
+          val prem_concls = map Logic.strip_assums_concl prems;
+
+          val vars = map_filter (try (
+            HOLogic.dest_Trueprop
+            #> strip_all
+            #> fst o dest_ordLess
+            #> dest_card_of
+            #> fst o Term.strip_comb
+            #> snd o Term.dest_Var
+            #> HOLogic.dest_setT o range_type
+          )) prem_concls;
+          val nvars = length vars;
+
+          val nind_cases = length (filter (
+            Term.exists_subterm (member (op=) (map Var P_vars))
+          ) (drop nvars prem_concls));
+
           val finsts = map_filter I (flat insts);
-          val avoiding_arbitraries = filter (fn arb =>
-            exists (Term.exists_subterm (curry (op=) arb)) (flat avoiding)
-          ) (map Free (flat arbitrary));
+          val avoiding_arbitraries = distinct (op=) (filter (fn arb =>
+            exists (Term.exists_subterm (curry (op=) arb)) avoiding
+          ) (map Free (flat arbitrary)));
           val avoiding_inducts = filter (fn (_, ind) =>
-              exists (Term.exists_subterm (curry (op=) ind)) (flat avoiding)
+              exists (Term.exists_subterm (curry (op=) ind)) avoiding
           ) (0 upto length finsts - 1 ~~ finsts);
+
+          fun extract_vars var t =
+            let
+              val T = fastype_of t
+              fun extract_deep T t = if Term.is_TFree T then
+                (if T = var then (SOME t, []) else (NONE, []))
+              else case try HOLogic.dest_setT T of
+                SOME T => (NONE, if T = var then [t] else [])
+                | NONE =>
+                  let
+                    val (name, Ts) = Term.dest_Type T
+                    (* TODO: special case sets for prod *)
+                    val sets = case MRBNF_Def.mrbnf_of ctxt name of
+                      SOME mrbnf => MRBNF_Def.sets_of_mrbnf mrbnf
+                      | NONE => (case BNF_Def.bnf_of ctxt name of
+                        SOME bnf => BNF_Def.sets_of_bnf bnf
+                        | NONE => error ("Type is neither a set nor a (MR)BNF: " ^ name)
+                      );
+                    val subst = Term.subst_atomic_types (rev (map TVar (Term.add_tvars (hd sets) [])) ~~ Ts);
+                    val sets' = map_filter (fn (T, s) => if Term.exists_subtype (curry (op=) var) T then
+                      SOME (T, subst s) else NONE) (Ts ~~ sets);
+                    val (ts, ts') = split_list (map (fn (T, s) => extract_deep T (case fastype_of t of
+                      Type (@{type_name set}, _) => MRBNF_Util.mk_UNION t s
+                      | _ => s $ t)) sets');
+                    val t = case ts of
+                      [] => NONE
+                      | _ => SOME (foldl1 MRBNF_Util.mk_Un (map_filter I ts))
+                  in (t, flat ts') end;
+            in if T = var then (SOME (HOLogic.mk_set T [t]), []) else extract_deep T t end
+
+          val terms_rawss = map (fn var =>
+            apfst (map_filter I) (apsnd flat (split_list (map (extract_vars var) avoiding)))
+          ) vars;
+
+          val goals = Logic.dest_conjunction_list (hd (Thm.prems_of st));
+
+          val cases_prems = drop nvars prems;
+          val K_vars = rev (distinct (op=) (filter (fn (_, T) =>
+            case try (HOLogic.dest_setT o range_type) T of
+              NONE => false
+              | SOME T => member (op=) vars T
+          ) (fold_rev Term.add_vars cases_prems [])));
+
+          fun strip_all t =
+            let fun go (Const ("Pure.all", _) $ Abs (x, T, t)) xs = go t (Free (x, T)::xs)
+                  | go t xs = (rev xs, subst_bounds (xs, t))
+            in go t [] end
+
+          val finsts' = map (map_filter I) insts;
+          val cases' = map (fn rule =>
+            let
+              val ((bvars, rho), rule) = apfst split_last (strip_all rule)
+              val (prems, outer_concl) = Logic.strip_horn rule;
+              val (P_var, P_args) = apsnd (fst o split_last) (Term.strip_comb (HOLogic.dest_Trueprop outer_concl));
+              val ((finst', goal), arb) = the (AList.lookup (op=) (map Var P_vars ~~ (finsts' ~~ goals ~~ arbitrary)) P_var);
+              val subst_ind = finst' ~~ P_args;
+
+              val prems' = maps (fn prem =>
+                let
+                  val (lvars, prem) = strip_all prem;
+                  val (prems, concl) = apsnd HOLogic.dest_Trueprop (Logic.strip_horn prem);
+                in if Term.exists_subterm (member (op=) (map Var K_vars)) concl then
+                  let
+                    val (z, (K_var, rho)) = apsnd Term.dest_comb (HOLogic.dest_mem (HOLogic.dest_not concl));
+                    val var_set_opt = try (snd o HOLogic.dest_mem o HOLogic.dest_Trueprop o hd) prems;
+                    val (terms, raws) = the (AList.lookup (op=) (map Var K_vars ~~ terms_rawss) K_var);
+
+                    val terms = map (Term.subst_atomic subst_ind) (filter (
+                      not o Term.exists_subterm (member (op=) (subtract (op=) finst' finsts))
+                    ) terms);
+
+                    fun dest_singleton (Const (@{const_name Set.insert}, _) $ t $ Const (@{const_name bot}, _)) = t
+                      | dest_singleton t = raise TERM ("dest_singleton", [t]);
+
+                    val prems' = case var_set_opt of
+                      SOME s => map (fn t => case try dest_singleton t of
+                        SOME x => HOLogic.mk_not (HOLogic.mk_mem (x, s))
+                        | NONE => MRBNF_Util.mk_int_empty (s, t)
+                      ) (terms @ raws)
+                      | NONE => map (fn t => case try dest_singleton t of
+                        SOME x => HOLogic.mk_not (HOLogic.mk_eq (z, x))
+                        | NONE => HOLogic.mk_not (HOLogic.mk_mem (z, t))
+                      ) (terms @ raws);
+                  in map HOLogic.mk_Trueprop prems' end
+                else
+                  let
+                    val (t, ts) = Term.strip_comb concl;
+                    val (concl', strip, arbs) = case AList.lookup (op=) (map Var P_vars ~~ (goals ~~ finsts' ~~ arbitrary)) t of
+                      SOME ((goal, inst), arbs) => (Term.subst_atomic (inst ~~ fst (split_last ts)) goal, true, arbs)
+                      | NONE => (HOLogic.mk_Trueprop concl, false, []);
+                    val prem' = fold_rev Logic.all ((if strip then fst (split_last lvars) else lvars) @ map Free arbs) (
+                      fold_rev (curry Logic.mk_implies) prems concl'
+                    );
+                  in [prem'] end
+                end
+              ) prems;
+            in fold_rev Logic.all (bvars @ map Free arb) (
+              fold_rev (curry Logic.mk_implies) prems' (Term.subst_atomic subst_ind goal)
+            ) end
+          ) cases_prems;
+
+          val bound_prems = flat (map2 (fn (_, raws) => fn var => map (fn raw => HOLogic.mk_Trueprop (
+            MRBNF_Util.mk_ordLess (MRBNF_Util.mk_card_of raw) (MRBNF_Util.mk_card_of (HOLogic.mk_UNIV var))
+          )) raws) terms_rawss vars);
+
+          val rule_t = fold_rev (curry Logic.mk_implies) (bound_prems @ cases') (
+            Logic.mk_conjunction_list goals
+          );
+
           val avoiding_dynamics = avoiding_arbitraries @ map snd avoiding_inducts;
           val avoiding_dynamic = HOLogic.mk_tuple avoiding_dynamics;
 
-          fun extract_vars t =
-            let
-              val T = fastype_of t
-              fun extract_deep T t = if T = var then (SOME t, []) else
-                case try HOLogic.dest_setT T of
-                  SOME T => if T = var then (NONE, [t]) else error "Wrong variable kind in set"
-                  | NONE =>
-                    let
-                      val (name, Ts) = Term.dest_Type T
-                      val sets = case MRBNF_Def.mrbnf_of ctxt name of
-                        SOME mrbnf => MRBNF_Def.sets_of_mrbnf mrbnf
-                        | NONE => (case BNF_Def.bnf_of ctxt name of
-                          SOME bnf => BNF_Def.sets_of_bnf bnf
-                          | NONE => error "Only single variables and variables in (MR)BNFs are supported, use the fset or set['a] (bounded set) BNFs instead of set"
-                        );
-                      val subst = Term.subst_atomic_types (rev (map TVar (Term.add_tvars (hd sets) [])) ~~ Ts);
-                      val sets' = map_filter (fn (T, s) => if Term.exists_subtype (curry (op=) var) T then
-                        SOME (T, subst s) else NONE) (Ts ~~ sets);
-                      val (ts, ts') = split_list (map (fn (T, s) => extract_deep T (case fastype_of t of
-                        Type (@{type_name set}, _) => MRBNF_Util.mk_UNION t s
-                        | _ => s $ t)) sets');
-                    in (SOME (foldl1 MRBNF_Util.mk_Un (map_filter I ts)), flat ts') end;
-            in if T = var then (SOME (HOLogic.mk_set T [t]), []) else extract_deep T t end
-
-          val (terms, raws) = apfst (map_filter I) (apsnd flat (split_list (map extract_vars (flat avoiding))));
-          val K_t = case flat avoiding of
-            [] => Term.abs ("\<rho>", HOLogic.unitT) (Const (@{const_name bot}, HOLogic.mk_setT var))
-            | _ =>
-              let val avoiding_set = foldl1 MRBNF_Util.mk_Un (terms @ raws);
-              in case avoiding_dynamics of
-                [] => Term.abs ("\<rho>", HOLogic.unitT) avoiding_set
-                | _ => MRBNF_Util.mk_case_tuple (map Term.dest_Free avoiding_dynamics) avoiding_set
-              end;
-
-          val arbitrary' = map Free (flat arbitrary);
-          val concl = Thm.concl_of rule
-          val P_var = hd (Term.add_vars concl [])
-          val P_new_var =
-            let val (Ts, T) = Term.strip_type (snd P_var);
-            in Var (fst P_var, fold_rev (curry op-->) (take (length Ts - 1) Ts @ map snd (flat arbitrary)) T) end;
-          val insts' = map_filter I (hd insts);
-          val P' = fold_rev Term.absfree (map (dest_Free o the) (hd insts)) (Term.abs ("\<rho>", fastype_of avoiding_dynamic) (Term.list_comb (P_new_var, insts' @ arbitrary')));
-          val rule'' = infer_instantiate' ctxt (map (SOME o Thm.cterm_of ctxt) [K_t, P']) rule;
-          val prems = drop more_consumes (Thm.cprems_of rule'')
-          val concl = Thm.concl_of rule''
-          val n = length arbitrary'
-
-          fun simplify_case_prod ((Const (@{const_name prod.case_prod}, _) $ Abs (_, _, Abs (_, _, t))) $ (Const (@{const_name Pair}, _) $ a $ b)) = Term.subst_bounds ([b, a], t)
-            | simplify_case_prod ((Const (@{const_name prod.case_prod}, _) $ Abs (_, _, t)) $ (Const (@{const_name Pair}, _) $ a $ b)) = Term.subst_bounds ([a], simplify_case_prod (t $ b))
-            | simplify_case_prod (a $ b) = simplify_case_prod a $ simplify_case_prod b
-            | simplify_case_prod (Abs (a, b, c)) = Abs (a, b, simplify_case_prod c)
-            | simplify_case_prod t = t
-
-          val prems_new = map (fn ct =>
-            let
-              val t = Thm.term_of ct
-              val vars = Term.strip_all_vars t
-              val body = Term.strip_all_body t
-              val vars_new = take (length vars - 1) vars
-              val ps = Logic.strip_imp_prems body
-              val cl = Logic.strip_imp_concl body
-              val comb = snd (Term.strip_comb (HOLogic.dest_Trueprop cl));
-              val avoid_inds = map (nth comb o fst) avoiding_inducts;
-              val ps' = map_index (fn (i, t) =>
-                let
-                  val p = HOLogic.dest_Trueprop t
-                  val (generalize, p') = case p of
-                    Const (@{const_name All}, _) $ Abs (_, _, v) =>
-                      let val (t, _) = Term.strip_comb v
-                      in if t = P_new_var then (true, Term.incr_boundvars (n - 1) v) else (false, p) end
-                    | _ => (false, p);
-
-                  val p'' = Term.incr_boundvars n (simplify_case_prod (
-                    Term.subst_bounds ([avoiding_dynamic], HOLogic.mk_Trueprop p')
-                  ));
-                  val p'' = if i = 0 then Term.subst_atomic (map snd avoiding_inducts ~~ avoid_inds) p'' else p''
-                in if generalize then fold_rev Logic.all arbitrary' p'' else p'' end
-              ) ps;
-
-              fun mk_all (x, T) t = Logic.all_const T $ Abs (x, T, t)
-              val t' = fold_rev mk_all vars_new (fold_rev Logic.all (map Free (flat arbitrary)) (
-                fold_rev (curry Logic.mk_implies) ps' (Term.incr_boundvars (n - 1) cl)
-              ));
-            in t' end
-          ) (tl prems);
-          val Const (@{const_name Trueprop}, _) $ (Const (@{const_name All}, _) $ Abs (_, _, concl_new)) = concl
-
-          fun mk_bound t = fold_rev Logic.all
-            (filter (fn arb => Term.exists_subterm (curry (op=) arb) t) avoiding_arbitraries) (HOLogic.mk_Trueprop (
-            MRBNF_Util.mk_ordLess (MRBNF_Util.mk_card_of t)
-              (MRBNF_Util.mk_card_of (HOLogic.mk_UNIV (HOLogic.dest_setT (fastype_of t))))
-          ));
-          val rule_new = fold_rev (curry Logic.mk_implies) (
-            take more_consumes (Thm.prems_of rule) @ map mk_bound raws @ prems_new
-          ) (HOLogic.mk_Trueprop concl_new);
-
           fun mk_all (a, b) c = HOLogic.mk_all (a, b, c)
-          val P2 = Free (hd (Term.variant_frees rule_new [("P", fastype_of P_new_var)]));
-          val P2_t = fold_rev Term.absfree (map dest_Free insts') (Term.abs ("\<rho>", fastype_of avoiding_dynamic) (
-            fold_rev mk_all (flat arbitrary) (
-              HOLogic.mk_imp (HOLogic.eq_const (fastype_of avoiding_dynamic) $ Bound n $ avoiding_dynamic, Term.list_comb (P2, insts' @ arbitrary')
-            )))
-          );
-          val rule_inst = fold (fn thm => fn thm2 => thm OF [thm2]) (replicate (1 + n) @{thm spec} @ [mp]) (infer_instantiate' ctxt (map (SOME o Thm.cterm_of ctxt) [K_t, P2_t]) rule)
-          fun rtac ctxt = resolve_tac ctxt o single
+          val rho = Free ("\<rho>", fastype_of avoiding_dynamic);
+          val inst_rule = infer_instantiate ctxt (map fst P_vars ~~
+            @{map 3} (fn goal => fn inst => fn arb => Thm.cterm_of ctxt (
+              fold_rev Term.absfree (map dest_Free inst) (Term.absfree (dest_Free rho) (
+                fold_rev mk_all arb (Induct.atomize_term ctxt (
+                  Logic.mk_implies (mk_Trueprop_eq (
+                    avoiding_dynamic, rho
+                  ), goal)
+                ))
+              ))
+            )) goals finsts' arbitrary
+          ) rule;
 
+          val inst_concl = Thm.concl_of inst_rule;
+          val inst_concls = Logic.dest_conjunction_list inst_concl;
+          fun dest_induct_imp (Const (@{const_name HOL.induct_implies}, _) $ t1 $ t2) = (t2, t1)
+
+          fun to_pure_all (Const ("HOL.All", _) $ Abs (a, b, t)) = to_pure_all (subst_bound (Free (a, b), t))
+            | to_pure_all t = apfst HOLogic.mk_Trueprop (dest_induct_imp t)
+          val (inst_concls', rho_imp) = split_list (map (to_pure_all o HOLogic.dest_Trueprop) inst_concls);
+
+          val inst_concl' = Logic.mk_implies (inst_concl, Logic.mk_implies (
+            HOLogic.mk_Trueprop (hd rho_imp),
+            Logic.mk_conjunction_list inst_concls'
+          ));
+          val inst_thm = Goal.prove_sorry ctxt [fst (dest_Free rho)] [] inst_concl' (fn {context=ctxt, ...} => EVERY1 [
+            K (Local_Defs.unfold0_tac ctxt @{thms atomize_conj HOL.induct_implies_def}),
+            REPEAT_DETERM o eresolve_tac ctxt [allE, conjE],
+            REPEAT_DETERM_N (length goals) o etac ctxt @{thm impE[OF _ refl]},
+            REPEAT_DETERM o EVERY' [
+              TRY o rtac ctxt conjI,
+              assume_tac ctxt
+            ]
+          ]);
+          val inst_rule = infer_instantiate ctxt (map fst K_vars ~~
+            map2 (fn (terms, raws) => fn var => Thm.cterm_of ctxt (
+              MRBNF_Util.mk_case_tuple (map dest_Free avoiding_dynamics) (
+                let val ts = terms @ raws
+                in if length ts = 0 then
+                  MRBNF_Util.mk_bot var
+                else foldl1 MRBNF_Util.mk_Un ts end
+              )
+            )) terms_rawss vars
+          ) inst_rule;
+
+          val mrbnf = hd (map_filter (Option.composePartial (
+            MRBNF_Def.mrbnf_of ctxt,
+            try (fst o dest_Type o fastype_of)
+          )) finsts);
           val bound_thms = [
             MRBNF_Def.Un_bound_of_mrbnf mrbnf,
             MRBNF_Def.UNION_bound_of_mrbnf mrbnf,
@@ -238,39 +316,61 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                   | NONE => []
             in maps (fn (s, Ts) => set_bd_of_T s @ get_set_bd Ts) Ts' end;
 
-          val set_bds = map (fn thm => @{thm ordLess_ordLeq_trans} OF [thm]) (get_set_bd (map fastype_of (flat avoiding)));
+          val set_bds = map (fn thm => @{thm ordLess_ordLeq_trans} OF [thm]) (get_set_bd (map fastype_of avoiding));
 
-          val rule_thm = Goal.prove_sorry defs_ctxt [fst (dest_Free P2)] [] (Term.subst_atomic [(P_new_var, P2)] rule_new) (fn {context=ctxt,...} =>
-            Subgoal.FOCUS_PREMS (fn {context=ctxt, prems, ...} =>
-              EVERY1 [
-                rtac ctxt rule_inst,
-                EVERY' (map (rtac ctxt) (take more_consumes prems)),
-                K (Local_Defs.unfold0_tac ctxt @{thms case_prod_beta}),
-                (* Boundness *)
-                rtac ctxt allI,
-                REPEAT_DETERM o resolve_tac ctxt (bound_thms @ set_bds @ prems @
-                  @{thms finite_ordLess_infinite2[OF finite_singleton cinfinite_imp_infinite]
-                    ordIso_ordLeq_trans[OF ordIso_symmetric[OF card_of_Field_ordIso]] emp_bound
-                  }
-                ),
-                (* others *)
+          val rule_thm = Goal.prove_sorry ctxt [] [] rule_t (fn {context=ctxt, ...} => EVERY1 [
+            REPEAT_DETERM o EqSubst.eqsubst_tac ctxt [0] @{thms induct_implies_eq},
+            Subgoal.FOCUS_PREMS (fn {context=ctxt, prems, ...} => EVERY1 [
+              rtac ctxt (inst_rule RS inst_thm),
+              K (Local_Defs.unfold0_tac ctxt @{thms case_prod_beta}),
+              (* boundness *)
+              REPEAT_DETERM o resolve_tac ctxt (bound_thms @ prems @ set_bds @
+                @{thms finite_ordLess_infinite2[OF finite_singleton cinfinite_imp_infinite]
+                  ordIso_ordLeq_trans[OF ordIso_symmetric[OF card_of_Field_ordIso]] emp_bound
+                }
+              ),
+              K (Local_Defs.unfold0_tac ctxt @{thms HOL.induct_implies_def}),
+              REPEAT_DETERM o Subgoal.FOCUS_PREMS (fn {context=ctxt, prems=inner_prems, ...} => EVERY1 [
+                REPEAT_DETERM o resolve_tac ctxt [allI, impI],
+                resolve_tac ctxt prems,
                 REPEAT_DETERM o FIRST' [
-                  resolve_tac ctxt ([refl, allI, impI] @ prems),
-                  eresolve_tac ctxt [allE],
-                  dresolve_tac ctxt @{thms mp[OF _ refl]},
-                  hyp_subst_tac ctxt,
+                  EVERY' [
+                    Method.insert_tac ctxt inner_prems,
+                    Goal.assume_rule_tac ctxt
+                  ],
+                  EVERY' [
+                    dresolve_tac ctxt inner_prems,
+                    REPEAT_DETERM o etac ctxt allE,
+                    etac ctxt impE,
+                    rtac ctxt refl,
+                    REPEAT_DETERM o (etac ctxt impE THEN' assume_tac ctxt),
+                    assume_tac ctxt
+                  ],
+                  EVERY' [
+                    TRY o (rtac ctxt @{thm iffD1[OF disjoint_single]} THEN' rtac ctxt @{thm trans[OF Int_commute]}),
+                    rtac ctxt @{thm iffD2[OF disjoint_iff]},
+                    rtac ctxt allI,
+                    rtac ctxt impI,
+                    dresolve_tac ctxt inner_prems,
+                    hyp_subst_tac ctxt,
+                    SELECT_GOAL (Local_Defs.unfold0_tac ctxt @{thms fst_conv snd_conv Un_iff de_Morgan_disj}),
+                    REPEAT_DETERM o etac ctxt conjE,
+                    assume_tac ctxt
+                  ],
                   assume_tac ctxt,
-                  EqSubst.eqsubst_asm_tac ctxt [0] @{thms snd_conv fst_conv}
+                  resolve_tac ctxt inner_prems
                 ]
-              ]
-            ) ctxt 1
-          );
+              ]) ctxt,
+              rtac ctxt refl
+            ]) ctxt
+          ]);
+
           val names = map (fst o dest_Free) (
-            fst (BNF_Util.mk_Frees "Bound" (map (K HOLogic.unitT) raws) ctxt)
+            fst (BNF_Util.mk_Frees "Bound" (map (K HOLogic.unitT) bound_prems) ctxt)
           );
           val names' = map (fn s => String.substring (s, 0, String.size s - 2)) names;
           val new_cases = map (fn s => ((s, []), [])) names'
-        in (((new_cases @ drop 1 cases, concls), (more_consumes, more_facts)), rule_thm) end
+        in (((new_cases @ drop nvars cases, concls), (more_consumes, more_facts)), rule_thm) end
       )
     |> Seq.maps (fn (((cases, concls), (more_consumes, more_facts)), rule) =>
           (PRECISE_CONJUNCTS (length concls) (ALLGOALS (fn j =>

--- a/Tools/binder_induction.ML
+++ b/Tools/binder_induction.ML
@@ -376,7 +376,7 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
             SOME thm' => thm :: repeat_mp thm'
             | NONE => [thm]
 
-          val _ = @{print} (inst_rule RS inst_thm)
+          (*val _ = @{print} (inst_rule RS inst_thm)*)
           val rule_thm = Goal.prove_sorry defs_ctxt [] [] rule_t (fn {context=ctxt, ...} => EVERY1 [
             K (Local_Defs.unfold0_tac ctxt @{thms induct_implies_eq induct_conj_eq}),
             K (print_tac ctxt "foo"),
@@ -387,7 +387,7 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                 val prems' = maps split_conjunction prems';
                 val _ = @{print} prems
               in EVERY1 [
-                rtac ctxt (inst_rule RS inst_thm),
+                rtac ctxt (Local_Defs.unfold0 ctxt @{thms HOL.induct_conj_eq} (inst_rule RS inst_thm)),
                 REPEAT_DETERM o resolve_tac ctxt prems,
                 K (Local_Defs.unfold0_tac ctxt @{thms case_prod_beta}),
                 (* boundness *)
@@ -396,7 +396,6 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                     ordIso_ordLeq_trans[OF ordIso_symmetric[OF card_of_Field_ordIso]] emp_bound
                   }
                 ),
-                K (print_tac ctxt "foo1"),
                 REPEAT_DETERM o EVERY' [
                   TRY o EVERY' [
                     dtac ctxt @{thm iffD1[OF arg_cong[of _ _ Not], rotated]},
@@ -414,17 +413,43 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                     dtac ctxt @{thm iffD1[OF meta_eq_to_obj_eq[OF HOL.induct_equal_def]]},
                 (*  ], *)
                   hyp_subst_tac ctxt,
+                  K (Local_Defs.unfold0_tac ctxt @{thms snd_conv fst_conv}),
+                  Subgoal.FOCUS_PREMS (fn {context=ctxt, prems=inner_prems, ...} => EVERY1 [
                   K (print_tac ctxt "wat1"),
-                  FIRST' (map (fn thm => resolve_tac ctxt (repeat_mp thm) THEN_ALL_NEW (EVERY' [
-                    REPEAT_DETERM o etac ctxt allE,
-                    REPEAT_DETERM o etac ctxt @{thm induct_impliesE[OF _ induct_equal_refl]},
-                    K (print_tac ctxt "wat2"),
-                    assume_tac ctxt
-                  ] ORELSE' EVERY' [
-                    SELECT_GOAL (print_tac ctxt "fail1"),
-                    assume_tac ctxt,
-                    SELECT_GOAL (print_tac ctxt "fail")
-                  ])) prems),
+                  FIRST' (map (fn thm => resolve_tac ctxt (repeat_mp thm) THEN_ALL_NEW (FIRST' [
+                    resolve_tac ctxt inner_prems THEN_ALL_NEW K no_tac,
+                    (* Extra higher order rules, no induction *)
+                    EVERY' [
+                      REPEAT_DETERM o rtac ctxt @{thm induct_impliesI},
+                      resolve_rule_tac ctxt inner_prems
+                    ],
+                    (* Higher order freshness *)
+                    EVERY' [
+                      TRY o (rtac ctxt @{thm iffD1[OF disjoint_single]} THEN' rtac ctxt @{thm trans[OF Int_commute]}),
+                      rtac ctxt @{thm iffD2[OF disjoint_iff]},
+                      rtac ctxt allI,
+                      rtac ctxt impI,
+                      dresolve_tac ctxt (@{print}inner_prems),
+                      SELECT_GOAL (Local_Defs.unfold0_tac ctxt @{thms Un_iff de_Morgan_disj}),
+                      REPEAT_DETERM o etac ctxt conjE,
+                      assume_tac ctxt
+                    ],
+                    (* Higher order induction hyp *)
+                    let
+                      val inner_prems' = map_filter (try (fn thm =>
+                        repeat_OF @{thm spec} thm RS @{thm induct_mp[OF _ induct_equal_refl]}
+                      )) inner_prems;
+                      val _ = @{print} inner_prems'
+                    in FIRST' [
+                      rtac ctxt @{thm induct_impliesI} THEN' eresolve_tac ctxt inner_prems',
+                      resolve_tac ctxt inner_prems'
+                    ] THEN_ALL_NEW K no_tac end,
+                    EVERY' [
+                      SELECT_GOAL (print_tac ctxt "fail"),
+                      K no_tac
+                    ]
+                  ])) prems)
+                  ]) ctxt,
                   K (print_tac ctxt "bar")
                   (*Subgoal.FOCUS_PREMS (fn {context=ctxt, prems=inner_prems, ...} => FIRST1 (map (fn p => EVERY' [
                     REPEAT_DETERM o rtac ctxt allI,

--- a/Tools/binder_induction.ML
+++ b/Tools/binder_induction.ML
@@ -90,7 +90,6 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
         SOME rs => inst_rule (Rule_Cases.strict_mutual_rule ctxt rs)
       | NONE => error "Automatic detection of induction rule is not supported yet, please specify with rule:"
       );
-      val _ = @{print} ruleq
 
       fun dest_ordLess t =
         let val t' = case HOLogic.dest_mem t of
@@ -110,15 +109,10 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
       |> Seq.maps (Rule_Cases.consume defs_ctxt (flat defs) facts)
       |> Seq.map (fn (((cases, concls), (more_consumes, more_facts)), rule) =>
         let
-          val _ = @{print} concls
-          val _ = @{print} cases
           val concl = Thm.concl_of rule
           val P_vars = rev (Term.add_vars concl []);
           val prems = Thm.prems_of rule
           val prem_concls = map Logic.strip_assums_concl prems;
-
-          val _ = @{print} rule
-          val _ = @{print} more_facts
 
           val vars_prems = map (try (
             HOLogic.dest_Trueprop
@@ -147,7 +141,7 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
             let
               val T = fastype_of t
               fun extract_deep T t = if T = var then (SOME t, []) else (
-                if Term.is_TFree var then (NONE, [])
+                if Term.is_TFree T then (NONE, [])
               else case try HOLogic.dest_setT T of
                 SOME T => (NONE, if T = var then [t] else [])
                 | NONE =>
@@ -171,14 +165,22 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                   in (t, flat ts') end);
             in if T = var then (SOME (HOLogic.mk_set T [t]), []) else extract_deep T t end
 
-          val _ = @{print} vars
           val terms_rawss = map (fn var =>
             apfst (map_filter I) (apsnd flat (split_list (map (extract_vars var) avoiding)))
           ) vars;
 
+          val more_facts' = map (fn thm =>
+            let
+              val t = Thm.prop_of thm;
+              val vars = rev (Term.add_vars t []);
+              val (vars', _) = mk_Frees "x" (map snd vars) ctxt
+              val t' = fold_rev Logic.all vars' (Term.subst_atomic (map Var vars ~~ vars') t);
+            in HOLogic.mk_Trueprop (Induct.atomize_term ctxt t') end
+          ) more_facts;
+
           val goals = (if length concls > 1 then Logic.dest_conjunction_list else single) (hd (Thm.prems_of st));
           val goals' = map (Logic.list_implies o apfst (drop nmajor) o Logic.strip_horn) goals;
-          val goals'' = map (fold_rev (curry Logic.mk_implies) (map Thm.prop_of more_facts)) goals';
+          val goals'' = map (fold_rev (curry Logic.mk_implies) more_facts') goals';
 
           val cases_prems = drop (nmajor + nvars) prems;
           val K_vars = rev (distinct (op=) (filter (fn (_, T) =>
@@ -309,14 +311,19 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
 
           val inst_concl' = Logic.mk_implies (inst_concl, Logic.mk_implies (
             HOLogic.mk_Trueprop (hd rho_imps),
-            fold_rev (curry Logic.mk_implies) (map Thm.prop_of more_facts) (Logic.mk_conjunction_list inst_concls')
+            fold_rev (curry Logic.mk_implies) more_facts' (Logic.mk_conjunction_list inst_concls')
           ));
           val inst_thm = Goal.prove_sorry defs_ctxt [fst (dest_Free rho)] [] inst_concl' (fn {context=ctxt, ...} => EVERY1 [
             K (Local_Defs.unfold0_tac ctxt (flat defs @ @{thms atomize_conj HOL.induct_implies_def})),
             REPEAT_DETERM o eresolve_tac ctxt [allE, conjE],
-            REPEAT_DETERM_N (length goals) o etac ctxt @{thm impE[OF _ refl]},
             REPEAT_DETERM o etac ctxt @{thm impE[OF _ induct_equal_refl]},
-            REPEAT_DETERM o (etac ctxt impE THEN' assume_tac ctxt),
+            REPEAT_DETERM o (etac ctxt impE THEN' FIRST' [
+              assume_tac ctxt,
+              EVERY' [
+                REPEAT_DETERM o resolve_tac ctxt @{thms induct_forallI impI},
+                Goal.assume_rule_tac ctxt
+              ]
+            ]),
             REPEAT_DETERM o EVERY' [
               TRY o rtac ctxt conjI,
               assume_tac ctxt
@@ -366,158 +373,87 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
             SOME thm' => repeat_OF thm thm'
             | NONE => thm2;
 
-          fun split_conjunction thm = case try (fn thm => (thm RS @{thm conjunctionD1}, thm RS @{thm conjunctionD2})) thm of
-            SOME (thms, thm) => split_conjunction thms @ [thm]
-            | NONE => [thm] (*if n = 1 then [thm]
-            else let val (thms, thm) = fold_map
-              (K (fn thm => )) (1 upto n - 1) thm
-            in thms @ [thm] end;*)
-
           fun repeat_mp thm = case try (fn thm => thm RS @{thm induct_mp}) thm of
             SOME thm' => thm :: repeat_mp thm'
             | NONE => [thm]
 
-          (*val _ = @{print} (inst_rule RS inst_thm)*)
-          val rule_thm = Goal.prove_sorry defs_ctxt [] [] rule_t (fn {context=ctxt, ...} => EVERY1 [
+          val rule_thm = Goal.prove_sorry defs_ctxt [] [] rule_t (fn {context=ctxt, ...} => let val ctxt' = ctxt in EVERY1 [
             K (Local_Defs.unfold0_tac ctxt @{thms induct_implies_eq induct_conj_eq}),
-            K (print_tac ctxt "foo"),
-            Subgoal.FOCUS_PREMS (fn {context=ctxt, prems, ...} =>
-              let
-                val ctxt' = ctxt;
-                val prems' = map (Local_Defs.unfold0 ctxt @{thms induct_implies_eq[symmetric]}) prems;
-                val prems' = maps split_conjunction prems';
-                val _ = @{print} prems
-              in EVERY1 [
-                rtac ctxt (Local_Defs.unfold0 ctxt @{thms HOL.induct_conj_eq} (inst_rule RS inst_thm)),
-                REPEAT_DETERM o resolve_tac ctxt prems,
-                K (Local_Defs.unfold0_tac ctxt @{thms case_prod_beta}),
-                (* boundness *)
-                REPEAT_DETERM o resolve_tac ctxt (bound_thms @ set_bds @ prems @
-                  @{thms allI finite_ordLess_infinite2[OF finite_singleton cinfinite_imp_infinite]
-                    ordIso_ordLeq_trans[OF ordIso_symmetric[OF card_of_Field_ordIso]] emp_bound
-                  }
-                ),
-                REPEAT_DETERM o EVERY' [
-                  TRY o EVERY' [
-                    dtac ctxt @{thm iffD1[OF arg_cong[of _ _ Not], rotated]},
-                    SELECT_GOAL (Local_Defs.unfold0_tac ctxt @{thms Un_iff}),
-                    rtac ctxt refl,
-                    REPEAT_DETERM o EVERY' [
-                      dtac ctxt @{thm iffD1[OF de_Morgan_disj]},
-                      etac ctxt conjE
-                    ],
-                    REPEAT_DETERM o dtac ctxt @{thm iffD1[OF arg_cong[OF singleton_iff, of Not]]}
+            Subgoal.FOCUS_PREMS (fn {context=ctxt, prems, ...} => EVERY1 [
+              rtac ctxt (Local_Defs.unfold0 ctxt @{thms HOL.induct_conj_eq} (inst_rule RS inst_thm)),
+              REPEAT_DETERM o resolve_tac ctxt prems,
+              K (Local_Defs.unfold0_tac ctxt @{thms case_prod_beta}),
+              (* boundness *)
+              REPEAT_DETERM o resolve_tac ctxt (bound_thms @ set_bds @ prems @
+                @{thms allI finite_ordLess_infinite2[OF finite_singleton cinfinite_imp_infinite]
+                  ordIso_ordLeq_trans[OF ordIso_symmetric[OF card_of_Field_ordIso]] emp_bound
+                }
+              ),
+              REPEAT_DETERM o EVERY' [
+                TRY o EVERY' [
+                  dtac ctxt @{thm iffD1[OF arg_cong[of _ _ Not], rotated]},
+                  SELECT_GOAL (Local_Defs.unfold0_tac ctxt @{thms Un_iff}),
+                  rtac ctxt refl,
+                  REPEAT_DETERM o EVERY' [
+                    dtac ctxt @{thm iffD1[OF de_Morgan_disj]},
+                    etac ctxt conjE
                   ],
-                  REPEAT_DETERM o rtac ctxt allI,
-                  (*REPEAT_DETERM o EVERY' [ *)
-                    rtac ctxt @{thm induct_impliesI[of "HOL.induct_equal _ _"]},
-                    dtac ctxt @{thm iffD1[OF meta_eq_to_obj_eq[OF HOL.induct_equal_def]]},
-                (*  ], *)
-                  hyp_subst_tac ctxt,
-                  K (Local_Defs.unfold0_tac ctxt @{thms snd_conv fst_conv}),
-                  Subgoal.FOCUS_PREMS (fn {context=ctxt, prems=inner_prems, ...} => EVERY1 [
-                  K (print_tac ctxt "wat1"),
-                  FIRST' (map (fn thm => resolve_tac ctxt (repeat_mp thm) THEN_ALL_NEW (FIRST' [
-                    resolve_tac ctxt (prems @ inner_prems) THEN_ALL_NEW K no_tac,
-                    (* Extra higher order rules, no induction *)
-                    EVERY' [
-                      REPEAT_DETERM o rtac ctxt @{thm induct_impliesI},
-                      resolve_rule_tac ctxt inner_prems
-                    ],
-                    (* Higher order freshness *)
-                    EVERY' [
-                      TRY o (rtac ctxt @{thm iffD1[OF disjoint_single]} THEN' rtac ctxt @{thm trans[OF Int_commute]}),
-                      rtac ctxt @{thm iffD2[OF disjoint_iff]},
-                      rtac ctxt allI,
-                      rtac ctxt impI,
-                      dresolve_tac ctxt (@{print}inner_prems),
-                      SELECT_GOAL (Local_Defs.unfold0_tac ctxt @{thms Un_iff de_Morgan_disj}),
-                      REPEAT_DETERM o etac ctxt conjE,
-                      assume_tac ctxt
-                    ],
-                    (* Higher order induction hyp *)
-                    let
-                      val inner_prems' = map_filter (try (fn thm =>
-                        repeat_OF @{thm spec} thm RS @{thm induct_mp[OF _ induct_equal_refl]}
-                      )) inner_prems;
-                      val _ = @{print} inner_prems'
-                    in FIRST' [
-                      rtac ctxt @{thm induct_impliesI} THEN' eresolve_tac ctxt inner_prems',
-                      resolve_tac ctxt inner_prems'
-                    ] THEN_ALL_NEW K no_tac end,
-                    EVERY' [
-                      SELECT_GOAL (print_tac ctxt "fail"),
-                      K no_tac
-                    ]
-                  ])) prems)
-                  ]) ctxt,
-                  K (print_tac ctxt "bar")
-                  (*Subgoal.FOCUS_PREMS (fn {context=ctxt, prems=inner_prems, ...} => FIRST1 (map (fn p => EVERY' [
-                    REPEAT_DETERM o rtac ctxt allI,
-                    rtac ctxt @{thm induct_impliesI},
-                    K (print_tac ctxt "1"),
-                    rtac ctxt (@{print}p),
-                    K (Local_Defs.unfold0_tac ctxt @{thms induct_implies_eq[symmetric] atomize_all[symmetric] HOL.induct_equal_def}),
-                    (* K (print_tac ctxt "2"), *)
-                    REPEAT_DETERM o (SELECT_GOAL (print_tac ctxt' "2") THEN' FIRST' [
-                      rtac ctxt @{thm conjunctionI},
-                      (* prems from original induction theorem *)
-                      resolve_tac ctxt inner_prems THEN_ALL_NEW (K no_tac),
-                      (* higher order prems from original induction theorem *)
-                      resolve_rule_tac ctxt inner_prems,
-
-                      assume_tac ctxt,
-                      (* higher order IHs *)
-                      SELECT_GOAL (EVERY1 [
-                        dresolve_tac ctxt inner_prems,
-                        REPEAT_DETERM o etac ctxt allE,
-                        etac ctxt @{thm induct_impliesE[OF _ refl]},
-                        REPEAT_DETERM o EVERY' [
-                          etac ctxt @{thm induct_impliesE},
-                          assume_tac ctxt
-                        ],
-                        assume_tac ctxt
-                      ]),
-                      (* IHs *)
-                      SELECT_GOAL (EVERY1 [
-                        eresolve_tac ctxt (@{print}(maps (split_conjunction o Local_Defs.unfold0 ctxt @{thms HOL.induct_rulify atomize_eq} o repeat_OF @{thm spec}) inner_prems)),
-                        K (print_tac ctxt "wat"),
-                        REPEAT_DETERM o assume_tac ctxt
-                      ]),
-                      SELECT_GOAL (EVERY1 [
-                        resolve_tac ctxt (maps (split_conjunction o repeat_OF @{thm induct_mp} o repeat_OF @{thm spec}) inner_prems),
-                        K (print_tac ctxt "wat2"),
-                        rtac ctxt refl,
-                        REPEAT_DETERM o assume_tac ctxt
-                      ]),
-                      (* freshness *)
-                      EVERY' [
-                        hyp_subst_tac ctxt,
-                        resolve_tac ctxt inner_prems THEN_ALL_NEW (K no_tac)
-                      ],
-                      SELECT_GOAL (EVERY1 [
-                        TRY o (rtac ctxt @{thm iffD1[OF disjoint_single]} THEN' rtac ctxt @{thm trans[OF Int_commute]}),
-                        rtac ctxt @{thm iffD2[OF disjoint_iff]},
-                        rtac ctxt allI,
-                        rtac ctxt impI,
-                        dresolve_tac ctxt inner_prems,
-                        hyp_subst_tac ctxt,
-                        SELECT_GOAL (Local_Defs.unfold0_tac ctxt @{thms fst_conv snd_conv Un_iff de_Morgan_disj}),
-                        REPEAT_DETERM o etac ctxt conjE,
-                        assume_tac ctxt
-                      ])
-                    ]),
-                    K (print_tac ctxt "end"),
-                    IF_UNSOLVED o K no_tac
-                  ]) prems')) ctxt,
-                  K (print_tac ctxt "endend") *)
+                  REPEAT_DETERM o dtac ctxt @{thm iffD1[OF arg_cong[OF singleton_iff, of Not]]}
                 ],
-                K (print_tac ctxt "foo"),
-                rtac ctxt @{thm induct_equal_refl},
-                REPEAT_DETERM o resolve_tac ctxt more_facts
-              ] end
-            ) ctxt
-          ]);
+                REPEAT_DETERM o rtac ctxt allI,
+                rtac ctxt @{thm induct_impliesI[of "HOL.induct_equal _ _"]},
+                dtac ctxt @{thm iffD1[OF meta_eq_to_obj_eq[OF HOL.induct_equal_def]]},
+                hyp_subst_tac ctxt,
+                K (Local_Defs.unfold0_tac ctxt @{thms snd_conv fst_conv}),
+                Subgoal.FOCUS_PREMS (fn {context=ctxt, prems=inner_prems, ...} => EVERY1 [
+                FIRST' (map (fn thm => resolve_tac ctxt (repeat_mp thm) THEN_ALL_NEW (FIRST' [
+                  resolve_tac ctxt inner_prems THEN_ALL_NEW K no_tac,
+                  (* Extra higher order rules, no induction *)
+                  EVERY' [
+                    REPEAT_DETERM o rtac ctxt @{thm induct_impliesI},
+                    resolve_rule_tac ctxt inner_prems
+                  ],
+                  (* Higher order freshness *)
+                  EVERY' [
+                    TRY o (rtac ctxt @{thm iffD1[OF disjoint_single]} THEN' rtac ctxt @{thm trans[OF Int_commute]}),
+                    rtac ctxt @{thm iffD2[OF disjoint_iff]},
+                    rtac ctxt allI,
+                    rtac ctxt impI,
+                    dresolve_tac ctxt inner_prems,
+                    SELECT_GOAL (Local_Defs.unfold0_tac ctxt @{thms Un_iff de_Morgan_disj}),
+                    REPEAT_DETERM o etac ctxt conjE,
+                    assume_tac ctxt
+                  ],
+                  (* freshness *)
+                  SELECT_GOAL (EVERY1 [
+                    SELECT_GOAL (Local_Defs.unfold0_tac ctxt @{thms Un_iff de_Morgan_disj}),
+                    REPEAT_DETERM1 o rtac ctxt conjI,
+                    REPEAT_DETERM1 o (resolve_tac ctxt inner_prems THEN_ALL_NEW K no_tac),
+                    IF_UNSOLVED o K no_tac
+                  ]),
+                  (* Higher order induction hyp *)
+                  let
+                    val inner_prems' = map_filter (try (fn thm =>
+                      repeat_OF @{thm spec} thm RS @{thm induct_mp[OF _ induct_equal_refl]}
+                    )) inner_prems;
+                  in FIRST' [
+                    rtac ctxt @{thm induct_impliesI} THEN' eresolve_tac ctxt inner_prems',
+                    resolve_tac ctxt inner_prems'
+                  ] THEN_ALL_NEW K no_tac end,
+                  EVERY' [
+                    SELECT_GOAL (print_tac ctxt "fail"),
+                    K no_tac
+                  ]
+                ])) prems)
+                ]) ctxt
+              ],
+              rtac ctxt @{thm induct_equal_refl},
+              REPEAT_DETERM o FIRST' [
+                resolve_tac ctxt (@{thms induct_forallI induct_impliesI} @ more_facts),
+                assume_tac ctxt
+              ]
+            ]) ctxt
+          ] end);
 
           val rule_thm = Local_Defs.unfold0 ctxt @{thms MRBNF_Recursor.prod_sets_simps} rule_thm;
           val names = map (fst o dest_Free) (
@@ -529,10 +465,8 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
       )
     |> Seq.maps (fn (((cases, concls), (more_consumes, more_facts)), rule) =>
         Induct.atomize_tac defs_ctxt i st
-        |> Seq.map @{print}
         |> Seq.maps (fn st' =>
-          Induct.guess_instance ctxt (@{print}(Induct.internalize ctxt (@{print}more_consumes) rule)) i (@{print}st')
-              |> Seq.map (fn x => (@{print} "foo"; x))
+          Induct.guess_instance ctxt (Induct.internalize ctxt more_consumes rule) i st'
               |> Seq.maps (fn rule' =>
                 CONTEXT_CASES (rule_cases ctxt rule' cases)
                   (resolve_tac defs_ctxt [rule'] i THEN

--- a/tests/Binder_Induction_Tests.thy
+++ b/tests/Binder_Induction_Tests.thy
@@ -12,10 +12,6 @@ lemmas T1_T2_strong_inducts' = T1.TT_fresh_induct_param_no_clash[unfolded ball_c
   T1.TT_fresh_induct_param_no_clash[unfolded ball_conj_distrib, THEN conjunct2]
 lemmas T1_T2_strong_inducts = T1_T2_strong_inducts'[of UNIV, unfolded ball_UNIV in_UNIV_imp, case_names Bound1 Bound2 T1_ctor T2_ctor]
 
-context begin
-ML_file \<open>../Tools/binder_induction.ML\<close>
-end
-
 lemma test1: "Q b x \<Longrightarrow> P (x::('a::{var_T1_pre,var_T2_pre}, 'b, 'c, 'd) T1)"
   "Q2 b y \<Longrightarrow> A (b::('a \<times> 'b) list) (c::'b list) (d::'a) \<Longrightarrow> P2 (y::('a, 'b::{var_T1_pre,var_T2_pre}, 'c::{var_T1_pre,var_T2_pre}, 'd) T2)"
 proof (binder_induction x and y arbitrary: b and c b avoiding: d c b x "{}::'b set" rule: T1_T2_strong_inducts)

--- a/tests/Binder_Induction_Tests.thy
+++ b/tests/Binder_Induction_Tests.thy
@@ -2,10 +2,6 @@ theory Binder_Induction_Tests
   imports "./VVSubst_Tests"
 begin
 
-context begin
-ML_file \<open>../Tools/binder_induction.ML\<close>
-end
-
 lemmas T1_T2_inducts = T1.TT_plain_co_induct[THEN conjunct1]
   T1.TT_plain_co_induct[THEN conjunct2]
 

--- a/tests/Binder_Induction_Tests.thy
+++ b/tests/Binder_Induction_Tests.thy
@@ -1,0 +1,32 @@
+theory Binder_Induction_Tests
+  imports "./VVSubst_Tests"
+begin
+
+context begin
+ML_file \<open>../Tools/binder_induction.ML\<close>
+end
+
+lemmas T1_T2_inducts = T1.TT_plain_co_induct[THEN conjunct1]
+  T1.TT_plain_co_induct[THEN conjunct2]
+
+lemma in_UNIV_imp: "(a \<in> UNIV \<Longrightarrow> PROP P) \<equiv> PROP P"
+  by simp
+
+lemmas T1_T2_strong_inducts' = T1.TT_fresh_induct_param_no_clash[unfolded ball_conj_distrib, THEN conjunct1]
+  T1.TT_fresh_induct_param_no_clash[unfolded ball_conj_distrib, THEN conjunct2]
+lemmas T1_T2_strong_inducts = T1_T2_strong_inducts'[of UNIV, unfolded ball_UNIV in_UNIV_imp, case_names Bound1 Bound2 T1_ctor T2_ctor]
+
+lemma test1: "Q b x \<Longrightarrow> P (x::('a::{var_T1_pre,var_T2_pre}, 'b, 'c, 'd) T1)"
+  "Q2 b y \<Longrightarrow> A (b::('a \<times> 'b) list) (c::'b list) (d::'a) \<Longrightarrow> P2 (y::('a, 'b::{var_T1_pre,var_T2_pre}, 'c::{var_T1_pre,var_T2_pre}, 'd) T2)"
+proof (binder_induction x and y arbitrary: b and c b avoiding: d c b x "{}::'b set" rule: T1_T2_strong_inducts)
+  case Bound
+  then show ?case by (rule emp_bound)
+next
+  case (T1_ctor v1 b)
+  then show ?case sorry
+next
+  case (T2_ctor v2 c b)
+  then show ?case sorry
+qed
+
+end

--- a/tests/Binder_Induction_Tests.thy
+++ b/tests/Binder_Induction_Tests.thy
@@ -12,6 +12,10 @@ lemmas T1_T2_strong_inducts' = T1.TT_fresh_induct_param_no_clash[unfolded ball_c
   T1.TT_fresh_induct_param_no_clash[unfolded ball_conj_distrib, THEN conjunct2]
 lemmas T1_T2_strong_inducts = T1_T2_strong_inducts'[of UNIV, unfolded ball_UNIV in_UNIV_imp, case_names Bound1 Bound2 T1_ctor T2_ctor]
 
+context begin
+ML_file \<open>../Tools/binder_induction.ML\<close>
+end
+
 lemma test1: "Q b x \<Longrightarrow> P (x::('a::{var_T1_pre,var_T2_pre}, 'b, 'c, 'd) T1)"
   "Q2 b y \<Longrightarrow> A (b::('a \<times> 'b) list) (c::'b list) (d::'a) \<Longrightarrow> P2 (y::('a, 'b::{var_T1_pre,var_T2_pre}, 'c::{var_T1_pre,var_T2_pre}, 'd) T2)"
 proof (binder_induction x and y arbitrary: b and c b avoiding: d c b x "{}::'b set" rule: T1_T2_strong_inducts)

--- a/tests/VVSubst_Tests.thy
+++ b/tests/VVSubst_Tests.thy
@@ -19,6 +19,7 @@ let
   val (_, lthy) = MRBNF_VVSubst.mrbnf_of_quotient_fixpoint [@{binding vvsubst_T1}, @{binding vvsubst_T2}] I fp_result lthy
 in lthy end
 \<close>
+declare [[quick_and_dirty=false]]
 print_theorems
 print_mrbnfs
 end

--- a/thys/MRBNF_Recursor.thy
+++ b/thys/MRBNF_Recursor.thy
@@ -322,6 +322,9 @@ lemmas induct_impliesI = impI[unfolded HOL.induct_implies_def[symmetric]]
 lemmas induct_impliesE = impE[unfolded HOL.induct_implies_def[symmetric]]
 lemmas induct_mp = mp[unfolded HOL.induct_implies_def[symmetric]]
 
+lemma induct_equal_ref: "HOL.induct_equal x x"
+  unfolding HOL.induct_equal_def by (rule refl)
+
 ML_file \<open>../Tools/mrbnf_fp_tactics.ML\<close>
 ML_file \<open>../Tools/mrbnf_fp_def_sugar.ML\<close>
 ML_file \<open>../Tools/mrbnf_fp.ML\<close>
@@ -336,8 +339,8 @@ ML_file \<open>../Tools/mrbnf_sugar.ML\<close>
 
 (*ML_file \<open>../Tools/binder_inductive.ML\<close>*)
 
-context begin
+(*context begin
 ML_file \<open>../Tools/binder_induction.ML\<close>
-end
+end*)
 
 end

--- a/thys/MRBNF_Recursor.thy
+++ b/thys/MRBNF_Recursor.thy
@@ -322,6 +322,7 @@ lemmas induct_impliesI = impI[unfolded HOL.induct_implies_def[symmetric]]
 lemmas induct_impliesE = impE[unfolded HOL.induct_implies_def[symmetric]]
 lemmas induct_mp = mp[unfolded HOL.induct_implies_def[symmetric]]
 lemmas induct_conjI = conjI[unfolded HOL.induct_conj_def[symmetric]]
+lemmas induct_forallI = allI[unfolded HOL.induct_forall_def[symmetric]]
 
 lemma induct_equal_refl: "HOL.induct_equal x x"
   unfolding HOL.induct_equal_def by (rule refl)

--- a/thys/MRBNF_Recursor.thy
+++ b/thys/MRBNF_Recursor.thy
@@ -321,8 +321,9 @@ lemma prod_sets_simps:
 lemmas induct_impliesI = impI[unfolded HOL.induct_implies_def[symmetric]]
 lemmas induct_impliesE = impE[unfolded HOL.induct_implies_def[symmetric]]
 lemmas induct_mp = mp[unfolded HOL.induct_implies_def[symmetric]]
+lemmas induct_conjI = conjI[unfolded HOL.induct_conj_def[symmetric]]
 
-lemma induct_equal_ref: "HOL.induct_equal x x"
+lemma induct_equal_refl: "HOL.induct_equal x x"
   unfolding HOL.induct_equal_def by (rule refl)
 
 ML_file \<open>../Tools/mrbnf_fp_tactics.ML\<close>

--- a/thys/MRBNF_Recursor.thy
+++ b/thys/MRBNF_Recursor.thy
@@ -313,6 +313,11 @@ lemma Int_image_imsupp: "imsupp f \<inter> A = {} \<Longrightarrow> A \<inter> f
 lemma Collect_prod_beta: "{(x, y). P x y} = {p. P (fst p) (snd p)}"
   by auto
 
+lemma prod_sets_simps:
+  "\<Union>(Basic_BNFs.fsts ` A) = fst ` A"
+  "\<Union>(Basic_BNFs.snds ` A) = snd ` A"
+  by force+
+
 ML_file \<open>../Tools/mrbnf_fp_tactics.ML\<close>
 ML_file \<open>../Tools/mrbnf_fp_def_sugar.ML\<close>
 ML_file \<open>../Tools/mrbnf_fp.ML\<close>
@@ -327,8 +332,8 @@ ML_file \<open>../Tools/mrbnf_sugar.ML\<close>
 
 (*ML_file \<open>../Tools/binder_inductive.ML\<close>*)
 
-context begin
+(*context begin
 ML_file \<open>../Tools/binder_induction.ML\<close>
-end
+end*)
 
 end

--- a/thys/MRBNF_Recursor.thy
+++ b/thys/MRBNF_Recursor.thy
@@ -318,6 +318,10 @@ lemma prod_sets_simps:
   "\<Union>(Basic_BNFs.snds ` A) = snd ` A"
   by force+
 
+lemmas induct_impliesI = impI[unfolded HOL.induct_implies_def[symmetric]]
+lemmas induct_impliesE = impE[unfolded HOL.induct_implies_def[symmetric]]
+lemmas induct_mp = mp[unfolded HOL.induct_implies_def[symmetric]]
+
 ML_file \<open>../Tools/mrbnf_fp_tactics.ML\<close>
 ML_file \<open>../Tools/mrbnf_fp_def_sugar.ML\<close>
 ML_file \<open>../Tools/mrbnf_fp.ML\<close>
@@ -332,8 +336,8 @@ ML_file \<open>../Tools/mrbnf_sugar.ML\<close>
 
 (*ML_file \<open>../Tools/binder_inductive.ML\<close>*)
 
-(*context begin
+context begin
 ML_file \<open>../Tools/binder_induction.ML\<close>
-end*)
+end
 
 end

--- a/thys/MRBNF_Recursor.thy
+++ b/thys/MRBNF_Recursor.thy
@@ -341,8 +341,8 @@ ML_file \<open>../Tools/mrbnf_sugar.ML\<close>
 
 (*ML_file \<open>../Tools/binder_inductive.ML\<close>*)
 
-(*context begin
+context begin
 ML_file \<open>../Tools/binder_induction.ML\<close>
-end*)
+end
 
 end

--- a/thys/POPLmark/POPLmark_1A.thy
+++ b/thys/POPLmark/POPLmark_1A.thy
@@ -202,7 +202,7 @@ proof -
           have "TyVar Y closed_in \<Gamma>, Z <: R, \<Delta>'" using SA_Trans_TVar(2) True u well_scoped(1) by fastforce
           then have "\<Gamma> , Z <: R , \<Delta>' \<turnstile> TyVar Y <: T" using SA_Trans_TVar True u by auto
           moreover have "\<Gamma>, Z <: R, \<Delta>' \<turnstile> R <: TyVar Y" using ty_weakening[OF ty_weakening_extend[OF SA_Trans_TVar(4)]]
-            by (metis SA_Trans_TVar.prems(2) True wf_ConsE wf_concatD)
+            by (metis SA_Trans_TVar(5) True wf_ConsE wf_concatD)
           ultimately have "\<Gamma> , Z <: R , \<Delta>' \<turnstile> R <: T" using ty_trans by blast
           then show ?thesis unfolding True u using ty.SA_Trans_TVar by auto
         next
@@ -221,8 +221,8 @@ proof -
           apply (rule wf_Cons)
           using SA_All UnI1 image_iff by auto
         have "\<Gamma> , X <: R, (\<Delta>', Z <: T\<^sub>1) \<turnstile> S\<^sub>2 <: T\<^sub>2"
-          apply (rule SA_All(8))
-          using 1 SA_All(9,11,12) by (auto intro!: SA_All(8))
+          apply (rule SA_All(10))
+          using 1 SA_All(12-14) by (auto intro!: SA_All(11))
         then show ?case using SA_All by auto
       qed (rule context_set_bd_UNIV | blast)+
     }
@@ -240,7 +240,7 @@ proof -
           then have u: "U = Top" using SA_Trans_TVar(1,2) context_determ wf_context by blast
           have "\<Gamma> , Z <: R , \<Delta>' \<turnstile> Top <: T" using SA_Trans_TVar True u by auto
           then have "\<Gamma> , Z <: R , \<Delta>' \<turnstile> R <: T"
-            by (metis SA_TopE SA_Trans_TVar.prems(1) ty_weakening ty_weakening_extend wf_ConsE wf_concatD)
+            by (metis SA_TopE SA_Trans_TVar(4) ty_weakening ty_weakening_extend wf_ConsE wf_concatD)
           then show ?thesis unfolding True u using ty.SA_Trans_TVar by auto
         next
           case False
@@ -258,8 +258,8 @@ proof -
           apply (rule wf_Cons)
           using SA_All UnI1 image_iff by auto
         have "\<Gamma> , X <: R, (\<Delta>', Z <: T\<^sub>1) \<turnstile> S\<^sub>2 <: T\<^sub>2"
-          apply (rule SA_All(8))
-          using 1 SA_All(9,11,12) by (auto intro!: SA_All(8))
+          apply (rule SA_All(10))
+          using 1 SA_All(12-14) by (auto intro!: SA_All(11))
         then show ?case using SA_All by auto
       qed (rule context_set_bd_UNIV | blast)+
     }
@@ -293,7 +293,7 @@ proof -
           have "(Q\<^sub>1 \<rightarrow> Q\<^sub>2) closed_in \<Gamma>, Z <: R, \<Delta>'" using SA_Trans_TVar(2) True u well_scoped(1) by fastforce
           then have "\<Gamma> , Z <: R , \<Delta>' \<turnstile> (Q\<^sub>1 \<rightarrow> Q\<^sub>2) <: T" using SA_Trans_TVar True u by auto
           moreover have "\<Gamma>, Z <: R, \<Delta>' \<turnstile> R <: (Q\<^sub>1 \<rightarrow> Q\<^sub>2)" using ty_weakening[OF ty_weakening_extend[OF SA_Trans_TVar(4)]]
-            by (metis SA_Trans_TVar.prems(2) True wf_ConsE wf_concatD)
+            by (metis SA_Trans_TVar(5) True wf_ConsE wf_concatD)
           ultimately have "\<Gamma> , Z <: R , \<Delta>' \<turnstile> R <: T" using ty_trans by blast
           then show ?thesis unfolding True u using ty.SA_Trans_TVar by auto
         next
@@ -312,8 +312,8 @@ proof -
           apply (rule wf_Cons)
           using SA_All UnI1 image_iff by auto
         have "\<Gamma> , X <: R, (\<Delta>', Z <: T\<^sub>1) \<turnstile> S\<^sub>2 <: T\<^sub>2"
-          apply (rule SA_All(8))
-          using 1 SA_All(9,11,12) by (auto intro!: SA_All(8))
+          apply (rule SA_All(10))
+          using 1 SA_All(12-14) by (auto intro!: SA_All(11))
         then show ?case using SA_All by auto
       qed (rule context_set_bd_UNIV | blast)+
     }
@@ -332,20 +332,20 @@ proof -
           then show ?case by (meson SA_Top ty.SA_All well_scoped(1))
         next
           case (SA_All \<Gamma> T\<^sub>1 T\<^sub>2)
-          have 1: "\<Gamma> \<turnstile> T\<^sub>1 <: S\<^sub>1" by (rule Forall(2)[OF SA_All(1,3)])
-          have "\<Gamma>, X <: T\<^sub>1 \<turnstile> S\<^sub>2 <: Q\<^sub>2" using Forall(3)[of \<emptyset> X \<Gamma> S\<^sub>2 Q\<^sub>2, OF _ SA_All(1)] SA_All(4)
+          have 1: "\<Gamma> \<turnstile> T\<^sub>1 <: S\<^sub>1" by (rule Forall(4)[OF SA_All(1,3)])
+          have "\<Gamma>, X <: T\<^sub>1 \<turnstile> S\<^sub>2 <: Q\<^sub>2" using Forall(5)[of \<emptyset> X \<Gamma> S\<^sub>2 Q\<^sub>2, OF _ SA_All(1)] SA_All(4)
             by (metis (mono_tags, lifting) SA_All(2) append.left_neutral fst_conv image_insert list.simps(15) well_scoped(1) wf_context)
-          then have "\<Gamma>, X <: T\<^sub>1 \<turnstile> S\<^sub>2 <: T\<^sub>2" by (rule Forall(4)[OF _ SA_All(2)])
+          then have "\<Gamma>, X <: T\<^sub>1 \<turnstile> S\<^sub>2 <: T\<^sub>2" by (rule Forall(6)[OF _ SA_All(2)])
           then show ?case using 1 by blast
         qed
       qed auto
     qed
     {
       case 1
-      then show ?case using ty_trans Forall(1) by blast
+      then show ?case using ty_trans Forall(2) by blast
     next
       case 2
-      then show ?case using Forall(1)
+      then show ?case using Forall(1-3)
       proof (binder_induction "\<Gamma>, Y <: (\<forall>X<:Q\<^sub>1. Q\<^sub>2), \<Delta>" M N arbitrary: \<Delta> avoiding: X Y "dom \<Gamma>" "dom \<Delta>" rule: ty_strong_induct)
         case (SA_Trans_TVar Z U T \<Delta>')
         then show ?case
@@ -355,8 +355,8 @@ proof -
           have "\<forall> X <: Q\<^sub>1 . Q\<^sub>2 closed_in \<Gamma>, Z <: R, \<Delta>'" using SA_Trans_TVar(2) True u well_scoped(1) by fastforce
           then have "\<Gamma> , Z <: R , \<Delta>' \<turnstile> \<forall> X <: Q\<^sub>1 . Q\<^sub>2 <: T" using SA_Trans_TVar True u by auto
           moreover have "\<Gamma>, Z <: R, \<Delta>' \<turnstile> R <: \<forall> X <: Q\<^sub>1 . Q\<^sub>2" using ty_weakening[OF ty_weakening_extend[OF SA_Trans_TVar(4)]]
-            by (metis SA_Trans_TVar.prems(2) True wf_ConsE wf_concatD)
-          moreover have "X \<notin> dom (\<Gamma> , Z <: R , \<Delta>')" using SA_Trans_TVar(8) True by auto
+            by (metis SA_Trans_TVar(5) True wf_ConsE wf_concatD)
+          moreover have "X \<notin> dom (\<Gamma> , Z <: R , \<Delta>')" using SA_Trans_TVar(8-10) True by auto
           ultimately have "\<Gamma>, Z <: R, \<Delta>' \<turnstile> R <: T" using ty_trans by blast
           then show ?thesis unfolding True u using ty.SA_Trans_TVar by auto
         next
@@ -375,7 +375,12 @@ proof -
           apply (rule wf_Cons)
           using SA_All UnI1 image_iff by auto
         have "\<Gamma> , Y <: R, (\<Delta>', Z <: T\<^sub>1) \<turnstile> S\<^sub>2 <: T\<^sub>2"
-          by (smt (verit) 1 SA_All(1,7-9,13) Un_commute Un_insert_left append_Cons fst_conv image_insert insert_iff list.simps(15) set_append well_scoped(1,2))
+          apply (rule SA_All(11))
+                 apply (simp add: SA_All 1)+
+          using SA_All.hyps(10) well_scoped(1) apply fastforce
+             apply (simp add: SA_All 1)
+          using SA_All.hyps(10) well_scoped(2) apply fastforce
+            using SA_All by (auto simp: 1)
         then show ?case using SA_All by auto
       qed (rule context_set_bd_UNIV | blast)+
     }

--- a/thys/POPLmark/POPLmark_1A.thy
+++ b/thys/POPLmark/POPLmark_1A.thy
@@ -19,14 +19,6 @@ lemma ty_strong_induct[consumes 1, case_names Bound SA_Top SA_Refl_TVar SA_Trans
 apply safe subgoal for p
 apply(rule BE_induct_ty[where \<phi> = "\<lambda> p \<Gamma> S T. P \<Gamma> S T p", of K])
 by (auto simp: small_def) .
-thm induct_impliesI[of "HOL.induct_equal _ _"]
-context begin
-ML_file \<open>../../Tools/binder_induction.ML\<close>
-end
-declare [[ML_print_depth=10000]]
-ML \<open>
-Multithreading.parallel_proofs := 0
-\<close>
 
 lemma ty_refl: "\<lbrakk> \<turnstile> \<Gamma> ok ; T closed_in \<Gamma> \<rbrakk> \<Longrightarrow> \<Gamma> \<turnstile> T <: T"
 proof (binder_induction T arbitrary: \<Gamma> avoiding: "dom \<Gamma>" rule: typ.strong_induct)

--- a/thys/POPLmark/POPLmark_1A.thy
+++ b/thys/POPLmark/POPLmark_1A.thy
@@ -19,7 +19,7 @@ lemma ty_strong_induct[consumes 1, case_names Bound SA_Top SA_Refl_TVar SA_Trans
 apply safe subgoal for p
 apply(rule BE_induct_ty[where \<phi> = "\<lambda> p \<Gamma> S T. P \<Gamma> S T p", of K])
 by (auto simp: small_def) .
-
+thm induct_impliesI[of "HOL.induct_equal _ _"]
 context begin
 ML_file \<open>../../Tools/binder_induction.ML\<close>
 end
@@ -116,28 +116,28 @@ using assms(1,2) proof (binder_induction \<Gamma> "\<forall>X<:S\<^sub>1. S\<^su
   case (SA_All \<Gamma> T\<^sub>1 R\<^sub>1 Y R\<^sub>2 T\<^sub>2)
   have 1: "\<forall>Y<:T\<^sub>1 . T\<^sub>2 = \<forall>X<:T\<^sub>1. rrename_typ (id(Y:=X,X:=Y)) T\<^sub>2"
     apply (rule Forall_swap)
-    using SA_All(1,7) well_scoped(2) by fastforce
+    using SA_All(6,9) well_scoped(2) by fastforce
   have fresh: "X \<notin> FFVars_typ T\<^sub>1"
-    by (meson SA_All(1,5) in_mono well_scoped(1))
-  have same: "R\<^sub>1 = S\<^sub>1" using SA_All(9) typ_inject(3) by blast
+    by (meson SA_All(4,9) in_mono well_scoped(1))
+  have same: "R\<^sub>1 = S\<^sub>1" using SA_All(8) typ_inject(3) by blast
   have x: "\<forall>Y<:S\<^sub>1. R\<^sub>2 = \<forall>X<:S\<^sub>1. rrename_typ (id(Y:=X,X:=Y)) R\<^sub>2"
     apply (rule Forall_swap)
-    by (metis (no_types, lifting) SA_All(9) assms(1,2) in_mono sup.bounded_iff typ.set(4) well_scoped(1))
+    by (metis (no_types, lifting) SA_All(8) assms(1,2) in_mono sup.bounded_iff typ.set(4) well_scoped(1))
   show ?case unfolding 1
     apply (rule Forall)
-    using same SA_All(5) apply simp
+    using same SA_All(4) apply simp
     apply (rule iffD2[OF arg_cong3[OF _ _ refl, of _ _ _ _ ty], rotated -1])
       apply (rule ty_eqvt)
-        apply (rule SA_All(7))
+        apply (rule SA_All(6))
        apply (rule bij_swap supp_swap_bound infinite_var)+
      apply (subst extend_eqvt)
        apply (rule bij_swap supp_swap_bound infinite_var)+
      apply (rule arg_cong3[of _ _ _ _ _ _ extend])
-    using SA_All(1,2) apply (metis bij_swap SA_All(5) Un_iff context_map_cong_id fun_upd_apply id_apply infinite_var supp_swap_bound wf_FFVars wf_context)
+    using SA_All(1,9) apply (metis bij_swap SA_All(4) Un_iff context_map_cong_id fun_upd_apply id_apply infinite_var supp_swap_bound wf_FFVars wf_context)
       apply simp
-    using fresh SA_All(4)
+    using fresh SA_All(3)
      apply (metis bij_swap fun_upd_apply id_apply infinite_var supp_swap_bound typ.rrename_cong_ids)
-    using x SA_All(9) unfolding same using Forall_inject_same by simp
+    using x SA_All(8) unfolding same using Forall_inject_same by simp
 qed (auto simp: Top)
 
 lemma SA_AllE2[consumes 2, case_names SA_Trans_TVar SA_All]:
@@ -149,31 +149,31 @@ using assms(1,2) proof (binder_induction \<Gamma> S "\<forall>X<:T\<^sub>1. T\<^
   case (SA_All \<Gamma> R\<^sub>1 S\<^sub>1 Y S\<^sub>2 R\<^sub>2)
   have 1: "\<forall>Y<:S\<^sub>1. S\<^sub>2 = \<forall>X<:S\<^sub>1. rrename_typ (id(Y:=X,X:=Y)) S\<^sub>2"
     apply (rule Forall_swap)
-    using SA_All(1,7) well_scoped(1) by fastforce
+    using SA_All(6,9) well_scoped(1) by fastforce
   have fresh: "X \<notin> dom \<Gamma>" "Y \<notin> dom \<Gamma>"
-    using SA_All(1) apply blast
-    by (metis SA_All(7) fst_conv wf_ConsE wf_context)
+    using SA_All(9) apply blast
+    by (metis SA_All(6) fst_conv wf_ConsE wf_context)
   have fresh2: "X \<notin> FFVars_typ T\<^sub>1" "Y \<notin> FFVars_typ T\<^sub>1"
-     apply (metis SA_All(5,9) in_mono fresh(1) typ_inject(3) well_scoped(1))
-    by (metis SA_All(5,9) in_mono fresh(2) typ_inject(3) well_scoped(1))
-  have same: "R\<^sub>1 = T\<^sub>1" using SA_All(9) typ_inject(3) by blast
+     apply (metis SA_All(4,8) in_mono fresh(1) typ_inject(3) well_scoped(1))
+    by (metis SA_All(4,8) in_mono fresh(2) typ_inject(3) well_scoped(1))
+  have same: "R\<^sub>1 = T\<^sub>1" using SA_All(8) typ_inject(3) by blast
   have x: "\<forall>Y<:T\<^sub>1 . R\<^sub>2 = \<forall>X<:T\<^sub>1. rrename_typ (id(Y:=X,X:=Y)) R\<^sub>2"
     apply (rule Forall_swap)
-    by (metis SA_All(9) Un_iff assms(1,2) in_mono typ.set(4) well_scoped(2))
+    by (metis SA_All(8) Un_iff assms(1,2) in_mono typ.set(4) well_scoped(2))
   show ?case unfolding 1
     apply (rule Forall)
-     apply (metis SA_All(5,9) typ_inject(3))
+     apply (metis SA_All(4,8) typ_inject(3))
     apply (rule iffD2[OF arg_cong3[OF _ refl, of _ _ _ _ ty], rotated -1])
       apply (rule ty_eqvt)
-        apply (rule SA_All(7))
+        apply (rule SA_All(6))
        apply (rule bij_swap supp_swap_bound infinite_var)+
      apply (subst extend_eqvt)
        apply (rule bij_swap supp_swap_bound infinite_var)+
      apply (rule arg_cong3[of _ _ _ _ _ _ extend])
-    using fresh apply (metis bij_swap SA_All(5) Un_iff context_map_cong_id fun_upd_apply id_apply infinite_var supp_swap_bound wf_FFVars wf_context)
+    using fresh apply (metis bij_swap SA_All(4) Un_iff context_map_cong_id fun_upd_apply id_apply infinite_var supp_swap_bound wf_FFVars wf_context)
       apply simp
     using fresh2 unfolding same apply (metis bij_swap fun_upd_apply id_apply infinite_var supp_swap_bound typ.rrename_cong_ids)
-    using SA_All(9) x Forall_inject_same unfolding same by simp
+    using SA_All(8) x Forall_inject_same unfolding same by simp
 qed (auto simp: TyVar)
 
 lemma ty_transitivity : "\<lbrakk> \<Gamma> \<turnstile> S <: Q ; \<Gamma> \<turnstile> Q <: T \<rbrakk> \<Longrightarrow> \<Gamma> \<turnstile> S <: T"
@@ -182,6 +182,7 @@ proof -
   have
     ty_trans: "\<lbrakk> \<Gamma> \<turnstile> S <: Q ; \<Gamma> \<turnstile> Q <: T \<rbrakk> \<Longrightarrow> \<Gamma> \<turnstile> S <: T"
   and ty_narrow: "\<lbrakk> (\<Gamma> , X <: Q), \<Delta> \<turnstile> M <: N ; \<Gamma> \<turnstile> R <: Q ; \<turnstile> \<Gamma> , X <: R, \<Delta> ok ; M closed_in \<Gamma> , X <: R, \<Delta> ; N closed_in \<Gamma> , X <: R, \<Delta> \<rbrakk> \<Longrightarrow> (\<Gamma>, X <: R), \<Delta> \<turnstile> M <: N"
+  (*proof (induction Q rule: typ.induct)*)
   proof (binder_induction Q arbitrary: \<Gamma> \<Delta> S T M N X R avoiding: X "dom \<Gamma>" "dom \<Delta>" rule: typ.strong_induct)
     case (TyVar Y \<Gamma> \<Delta> S T M N X R)
     {

--- a/thys/Pi_Calculus/Pi.thy
+++ b/thys/Pi_Calculus/Pi.thy
@@ -4,12 +4,7 @@ theory Pi
 imports "../MRBNF_Recursor" "HOL-Library.FSet" 
  "../Instantiation_Infrastructure/FixedCountableVars"
  "../General_Customization"
-begin 
-
-context begin
-ML_file \<open>../../Tools/binder_induction.ML\<close>
-end
-
+begin
 
 (* DATATYPE DECLARTION  *)
 

--- a/thys/Untyped_Lambda_Calculus/ILC.thy
+++ b/thys/Untyped_Lambda_Calculus/ILC.thy
@@ -6,11 +6,6 @@ imports "../MRBNF_Recursor"
  "../Prelim/More_Stream"
 begin
 
-
-context begin
-ML_file \<open>../../Tools/binder_induction.ML\<close>
-end
-
 (* We register distinct streams: *)
 mrbnf "'a ::infinite_regular dstream"
   map: dsmap

--- a/thys/Untyped_Lambda_Calculus/LC.thy
+++ b/thys/Untyped_Lambda_Calculus/LC.thy
@@ -6,11 +6,6 @@ imports "../MRBNF_Recursor" "HOL-Library.FSet"
  "../Prelim/More_List"
 begin
 
-context begin
-ML_file \<open>../../Tools/binder_induction.ML\<close>
-end
-
-
 (* DATATYPE DECLARTION  *)
 
 (* binder_datatype 'a term =


### PR DESCRIPTION
It can now handle mutual induction, more than one variable kind to be avoided and higher order induction rules like the ones directly from the fixpoint code.

ISSUES FIXES: #27 