### PR TITLE
Unary Substitution

### DIFF
--- a/Tools/binder_induction.ML
+++ b/Tools/binder_induction.ML
@@ -470,32 +470,37 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                      they match and resolution does not fail for goals with >= 2 conjuncts *)
                   K (Local_Defs.unfold0_tac ctxt @{thms conj_assoc}),
                   DETERM o resolve_tac ctxt (IH :: repeat_mp IH),
-                  IF_UNSOLVED o EVERY' [
-                    K (Local_Defs.unfold0_tac ctxt @{thms notin_Un Un_iff de_Morgan_disj singleton_iff Int_Un_distrib Un_empty}),
-                    EVERY' (map (fn inner_prem => EVERY' (map (fn tac => DETERM o tac) [
-                      REPEAT_DETERM o rtac ctxt conjI,
-                      let val x = length (fst (Logic.strip_horn (Thm.prop_of inner_prem)));
-                      in REPEAT_DETERM_N x o rtac ctxt @{thm induct_impliesI} end,
-                      REPEAT_DETERM o rtac ctxt @{thm induct_forallI},
-                      rtac ctxt inner_prem ORELSE'
-                      EVERY' [
-                        Method.insert_tac ctxt inner_prems,
-                        let
-                          val simpset = Simplifier.add_cong @{thm imp_cong} (
-                            (BNF_Util.ss_only @{thms
-                              split_paired_All HOL.simp_thms all_simps HOL.induct_forall_def prod.inject induct_implies_equal_eq
-                              disjoint_single trans[OF arg_cong2[OF Int_commute refl, of "(=)"] disjoint_single] conj_assoc
-                            } ctxt)
-                            |> fold Simplifier.add_proc [@{simproc HOL.defined_All}, @{simproc HOL.defined_Ex}]
-                          )
-                        in Simplifier.asm_full_simp_tac simpset end
-                      ],
-                      REPEAT_DETERM o assume_tac ctxt
-                    ])) (map (fn thm => case try (fn () => repeat_spec thm RS @{thm induct_mp[OF _ induct_equal_refl]}) () of
-                      SOME thm' => thm'
-                      | NONE => thm
-                    ) inner_prems))
-                  ]
+                  (* discharge the remaining obligations by search rather than by pairing them
+                     positionally with the hypotheses (a bare atom in `avoiding:` splits one
+                     freshness goal into several, breaking the alignment): `close` tries an
+                     assumption, reflexivity, a structural intro, the freshness simp, or resolution
+                     with a hypothesis, recursing into the premises it introduces. Resolution
+                     backtracks, so when two hypotheses share a conclusion the wrong choice dead-ends
+                     on an unprovable premise and the other is found. REPEAT_DETERM runs it over all
+                     the siblings that resolving the IH left. *)
+                  IF_UNSOLVED o
+                  (let
+                    val facts = maps (fn thm =>
+                      the_list (try (fn () =>
+                        repeat_spec thm RS @{thm induct_mp[OF _ induct_equal_refl]}) ())
+                      @ [thm]) inner_prems;
+                    val fresh_simp =
+                      Method.insert_tac ctxt inner_prems THEN'
+                      Simplifier.asm_full_simp_tac (Simplifier.add_cong @{thm imp_cong} (
+                        (BNF_Util.ss_only @{thms
+                          notin_Un Un_iff de_Morgan_disj singleton_iff Int_Un_distrib Un_empty
+                          split_paired_All HOL.simp_thms all_simps HOL.induct_forall_def prod.inject induct_implies_equal_eq
+                          disjoint_single trans[OF arg_cong2[OF Int_commute refl, of "(=)"] disjoint_single] conj_assoc
+                        } ctxt)
+                        |> fold Simplifier.add_proc [@{simproc HOL.defined_All}, @{simproc HOL.defined_Ex}]));
+                    fun close i st = FIRST' [
+                        assume_tac ctxt,
+                        rtac ctxt @{thm induct_equal_refl},
+                        resolve_tac ctxt @{thms induct_forallI induct_impliesI conjI} THEN_ALL_NEW close,
+                        SOLVED' fresh_simp,
+                        resolve_tac ctxt facts THEN_ALL_NEW close
+                      ] i st;
+                  in REPEAT_DETERM o close end)
                 ]) ctxt
               ]) (let val xs = drop (nmajor + length bound_prems) prems
                   in take (length xs - length other_assms) xs end)),

--- a/Tools/binder_induction.ML
+++ b/Tools/binder_induction.ML
@@ -465,6 +465,10 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                   ]
                 ],
                 Subgoal.FOCUS_PREMS (fn {context=ctxt, prems=inner_prems, ...} => EVERY1 [
+                  (* the induction machinery may left-associate the conclusion's conjunctions,
+                     while the case hypothesis (IH) keeps them right-associated; normalise so
+                     they match and resolution does not fail for goals with >= 2 conjuncts *)
+                  K (Local_Defs.unfold0_tac ctxt @{thms conj_assoc}),
                   DETERM o resolve_tac ctxt (IH :: repeat_mp IH),
                   IF_UNSOLVED o EVERY' [
                     K (Local_Defs.unfold0_tac ctxt @{thms notin_Un Un_iff de_Morgan_disj singleton_iff Int_Un_distrib Un_empty}),

--- a/Tools/binder_induction.ML
+++ b/Tools/binder_induction.ML
@@ -482,7 +482,7 @@ fun gen_binder_context_tactic mod_cases simp def_insts arbitrary avoiding taking
                               split_paired_All HOL.simp_thms all_simps HOL.induct_forall_def prod.inject induct_implies_equal_eq
                               disjoint_single trans[OF arg_cong2[OF Int_commute refl, of "(=)"] disjoint_single] conj_assoc
                             } ctxt)
-                            addsimprocs [@{simproc HOL.defined_All}, @{simproc HOL.defined_Ex}]
+                            |> fold Simplifier.add_proc [@{simproc HOL.defined_All}, @{simproc HOL.defined_Ex}]
                           )
                         in Simplifier.asm_full_simp_tac simpset end
                       ],

--- a/Tools/binder_inductive.ML
+++ b/Tools/binder_inductive.ML
@@ -530,7 +530,12 @@ fun binder_inductive_cmd (((options, pred_name), binds_opt: (string * string lis
           | UNIV_cinfinite_of_mr_bnf (Inr (Inr sugar)) = (case MRBNF_Def.mrbnf_of lthy (fst (dest_Type (#T sugar))) of
             SOME mrbnf => [MRBNF_Def.UNIV_cinfinite_of_mrbnf mrbnf] | NONE => [])
           | UNIV_cinfinite_of_mr_bnf _ = []
-        val infinite_UNIVs = map (fn thm => @{thm cinfinite_imp_infinite} OF [thm]) (maps UNIV_cinfinite_of_mr_bnf (flat mr_bnfs));
+        (* fallback appended after the MRBNF-derived facts (so those win): a `var`-sort type has
+           infinite UNIV by the class axiom alone, covering a bound-variable type the walk above
+           doesn't reach, e.g. one nested in a plain `set`/`prod` container *)
+        val infinite_UNIVs =
+          map (fn thm => @{thm cinfinite_imp_infinite} OF [thm]) (maps UNIV_cinfinite_of_mr_bnf (flat mr_bnfs))
+          @ [@{thm cinfinite_imp_infinite} OF [@{thm var_class.UNIV_cinfinite}]];
 
         val supp_smallss = transpose (map (fn supp_smalls => prove_missing supp_smalls
           (fn ctxt => fn mr_bnfs => K (EVERY1 [

--- a/Tools/binder_inductive.ML
+++ b/Tools/binder_inductive.ML
@@ -444,7 +444,7 @@ fun binder_inductive_cmd (((options, pred_name), binds_opt: (string * string lis
         ]));
         val perm_comps = prove_missing perm_comps (fn ctxt => fn mr_bnfs => K (EVERY1 [
           K (Local_Defs.unfold0_tac ctxt (@{thms id_apply id_o o_id} @ maps map_comp_of_mr_bnf mr_bnfs)),
-          rtac ctxt refl
+          resolve_tac ctxt @{thms refl comp_apply[symmetric]}
         ]));
 
         fun set_map_of_mr_bnf (Inl mrbnf) = MRBNF_Def.set_map_of_mrbnf mrbnf
@@ -453,7 +453,7 @@ fun binder_inductive_cmd (((options, pred_name), binds_opt: (string * string lis
 
         val supp_seminatss = transpose (map (fn thms => prove_missing thms (fn ctxt => fn mr_bnfs => K (EVERY1 [
           K (Local_Defs.unfold0_tac ctxt (
-            @{thms image_empty image_comp[unfolded comp_def] image_UN[symmetric] image_Un[symmetric]}
+            @{thms image_empty image_insert image_comp[unfolded comp_def] image_UN[symmetric] image_Un[symmetric]}
             @ maps set_map_of_mr_bnf mr_bnfs
           )),
           rtac ctxt @{thm subset_refl}
@@ -472,7 +472,11 @@ fun binder_inductive_cmd (((options, pred_name), binds_opt: (string * string lis
 
         val perm_supports = prove_missing perm_supports (fn ctxt => fn mr_bnfs => fn i =>
           let val supps = nth suppss i;
-          in rtac ctxt @{thm id_apply} 1 ORELSE EVERY1 (map (fn j => REPEAT_DETERM o SELECT_GOAL (EVERY1 [
+          in rtac ctxt @{thm id_apply} 1
+            (* atom component: id_on {x} \<sigma> \<Longrightarrow> \<sigma> x = x *)
+            ORELSE SOLVED' (Subgoal.FOCUS_PREMS (fn {context=ctxt', prems, ...} =>
+              HEADGOAL (resolve_tac ctxt' prems THEN' resolve_tac ctxt' @{thms singletonI insertI1})) ctxt) 1
+            ORELSE EVERY1 (map (fn j => REPEAT_DETERM o SELECT_GOAL (EVERY1 [
             REPEAT_DETERM o EVERY' [
               resolve_tac ctxt (map map_cong_id_of_mr_bnf mr_bnfs),
               REPEAT_DETERM o (assume_tac ctxt ORELSE' resolve_tac ctxt @{thms supp_id_bound bij_id})
@@ -531,7 +535,7 @@ fun binder_inductive_cmd (((options, pred_name), binds_opt: (string * string lis
         val supp_smallss = transpose (map (fn supp_smalls => prove_missing supp_smalls
           (fn ctxt => fn mr_bnfs => K (EVERY1 [
             REPEAT_DETERM o resolve_tac ctxt (
-              @{thms emp_bound ordLeq_refl card_of_Card_order} @ [Un_bound, UN_bound, var_large]
+              @{thms emp_bound ordLeq_refl card_of_Card_order finite_ordLess_infinite2[OF finite_singleton]} @ [Un_bound, UN_bound, var_large]
               @ maps set_bd_UNIVs_of_mr_bnfs mr_bnfs @ infinite_UNIVs
             )
           ]))

--- a/Tools/equivariance.ML
+++ b/Tools/equivariance.ML
@@ -108,7 +108,12 @@ val _ = Theory.local_setup (fn lthy =>
                 | map_id0s_of_mr_bnf (Inr (Inl bnf)) = BNF_Def.map_id0_of_bnf bnf
                 | map_id0s_of_mr_bnf (Inr (Inr quot)) = #permute_id0 quot
 
-              val thm' = Goal.prove_sorry lthy (map fst vars) [] goal (fn {context=ctxt, ...} => EVERY1 [
+              (* reflexive when the arguments carry no permutation action; the tactic below
+                 assumes a non-trivial one, so close this case directly *)
+              val thm' = Goal.prove_sorry lthy (map fst vars) [] goal (fn {context=ctxt, ...} =>
+                if HOLogic.dest_Trueprop lhs aconv HOLogic.dest_Trueprop rhs
+                then HEADGOAL (rtac ctxt refl)
+                else EVERY1 [
                 rtac ctxt iffI,
                 defer_tac,
                 etac ctxt (Drule.rotate_prems ~1 thm),

--- a/Tools/mrbnf_fp.ML
+++ b/Tools/mrbnf_fp.ML
@@ -49,7 +49,7 @@ type mrbnf_fp_model = {
 fun primrec int fixes specs lthy: (term list * thm list * thm list list) * local_theory =
   let
     val ((_, (terms, defs, (_, simpss))), lthy) =
-      BNF_LFP_Rec_Sugar.primrec_simple int fixes specs lthy;
+      BNF_LFP_Rec_Sugar.primrec_simple {verbose=int} fixes specs lthy;
   in
     ((terms, defs, simpss), lthy)
   end;
@@ -58,7 +58,7 @@ fun primcorec int fixes specs lthy: (term list * thm list * thm list list) * loc
     val decl = fixes |> Free o apfst Binding.name_of o fst o hd;
     val specs' = map (pair (Binding.empty, [])) specs;
   in
-    BNF_GFP_Rec_Sugar.primcorec_ursive int true [] fixes specs' (replicate (length specs) NONE) lthy
+    BNF_GFP_Rec_Sugar.primcorec_ursive {verbose=int, auto=true} [] fixes specs' (replicate (length specs) NONE) lthy
     |> (fn (goalss, after_qed, lthy) => lthy
       |> after_qed (map (fn [] => [] | _ => error "\"auto\" failed") goalss))
     |> `(fn lthy: local_theory => nth (Spec_Rules.retrieve lthy decl) 1

--- a/Tools/mrbnf_recursor.ML
+++ b/Tools/mrbnf_recursor.ML
@@ -319,7 +319,7 @@ fun define_recursor_consts qualify (fp_res : MRBNF_FP_Def_Sugar.fp_result) fp_bs
             (Const (@{const_name undefined}, uT))
         )) uTs model_consts lhss map_ts;
 
-        val lthy = snd (Function.add_function
+        val lthy = snd (Function.add_function {verbose=false}
           (map (fn f => (Binding.concealed (Binding.name (fst (dest_Free f))), NONE, NoSyn)) fs)
           (map (fn eq => (((Binding.concealed Binding.empty, []), eq), [], [])) eqs)
           Function_Common.default_config (mk_f_pat_complete_tac (map #inject (#raw_fps fp_res))) lthy

--- a/Tools/mrbnf_sugar.ML
+++ b/Tools/mrbnf_sugar.ML
@@ -1270,10 +1270,12 @@ fun create_binder_datatype co (spec : spec) lthy =
 
           fun is_RVr (NT, x) =
             let
-              val Inj_count = fold (fn Ts => fn cnt =>
-                cnt + (if member (op=) Ts (TFree NT) then 1 else 0)
-              ) ctor_Ts 0;
-            in x = Free_Var andalso Inj_count <> 1 end;
+              val (Inj_count, arity) = fold (fn Ts => fn (cnt, arity) =>
+                (if member (op=) Ts (TFree NT)
+                  then (1 + cnt, arity orelse length Ts > 1)
+                  else (cnt, arity))
+              ) ctor_Ts (0, false);
+            in x = Free_Var andalso (Inj_count <> 1 orelse arity) end;
 
           val RVr_Ns = filter is_RVr (#vars spec)
             |> map ((fn N => String.extract (N, 1, NONE)) o fst o fst);

--- a/Tools/mrbnf_sugar.ML
+++ b/Tools/mrbnf_sugar.ML
@@ -1265,22 +1265,23 @@ fun create_binder_datatype co (spec : spec) lthy =
         NONE => (NONE, lthy)
       | SOME tvsubst =>
         let
-          (* prepare spec (we need the original tv names for RVrs) *)
-          val ctor_Ts = map snd (#ctors spec);
+          (* A binding-related free var gets a renaming (RVr) delta in Sb iff it has no
+             eta ctor; mirror the eta condition of tvsubst_model (single-arg ctor whose
+             var occurs in no other ctor, nested occurrences included). We need the
+             original tv names from the spec for the RVr binding names. *)
+          fun has_eta NT = #ctors spec
+            |> map_index I
+            |> exists (fn (i, (_, tys)) => tys = [TFree NT] andalso
+                not (member (op=) (fold Term.add_tfreesT
+                  (maps snd (nth_drop i (#ctors spec))) []) NT));
 
           fun is_RVr (NT, x) =
-            let
-              val (Inj_count, arity) = fold (fn Ts => fn (cnt, arity) =>
-                (if member (op=) Ts (TFree NT)
-                  then (1 + cnt, arity orelse length Ts > 1)
-                  else (cnt, arity))
-              ) ctor_Ts (0, false);
-            in x = Free_Var andalso (Inj_count <> 1 orelse arity) end;
+            x = Free_Var andalso member (op=) frees (TFree NT) andalso not (has_eta NT);
 
           val RVr_Ns = filter is_RVr (#vars spec)
             |> map ((fn N => String.extract (N, 1, NONE)) o fst o fst);
         in
-          TVSubst.create_tvsubst1_of_result (#tvsubst_b spec, RVr_Ns) tvsubst lthy
+          TVSubst.create_tvsubst1_of_result (#tvsubst_b spec, RVr_Ns) (tvsubst, permute_simps) lthy
           |> apfst SOME
         end);
 
@@ -1363,9 +1364,7 @@ fun create_binder_datatype co (spec : spec) lthy =
         ("IImsupp_permute_commute", #IImsupp_permute_commutes res, []),
         ("IImsupp_Diff", #IImsupp_Diffs res, []),
         ("tvsubst_permute", [#tvsubst_permute res], [])
-      ]) tvsubst_opt) @ the_default [] (Option.map (map (fn (N, tvsubst1_simps) =>
-        (N, tvsubst1_simps, simp)
-      )) tvsubst1_opt))
+      ]) tvsubst_opt) @ the_default [] tvsubst1_opt)
         |> filter_out (null o #2)
         |> (map (fn (thmN, thms, attrs) =>
         ((Binding.qualify true (Binding.name_of (#fp_b spec)) (Binding.name thmN), attrs), [(thms, [])])

--- a/Tools/mrbnf_sugar.ML
+++ b/Tools/mrbnf_sugar.ML
@@ -79,7 +79,7 @@ fun create_binder_type (fp : MRBNF_Util.fp_kind) (spec : spec) lthy =
     val ((mrsbnf, (Ds, absinfo)), lthy) = MRSBNF_Comp.seal_mrsbnf I (bmv_unfolds
       @ BMV_Monad_Def.unfolds_of_bmv_monad (MRSBNF_Def.bmv_monad_of_mrsbnf mrsbnf), snd accum)
       (Binding.name pre_name) (#vars spec) tys mrsbnf NONE lthy;
-    
+
     val mrbnf = hd (MRSBNF_Def.mrbnfs_of_mrsbnf mrsbnf);
 
     val FVars_names = case #set_bs spec of
@@ -1146,7 +1146,7 @@ fun create_binder_datatype co (spec : spec) lthy =
         (single o HOLogic.mk_Trueprop o mk_bij) bounds mapx tac
       end;
 
-    val (lthy, tvsubst_opt) = if not (null (map_filter I (#etas tvsubst_model))) andalso not co then
+    val (tvsubst_opt, lthy) = if not (null (map_filter I (#etas tvsubst_model))) andalso not co then
       let
         val recursor_result = #recursor_result (the vvsubst_res_opt);
         val rec_mrbnf = #rec_mrbnf (the vvsubst_res_opt);
@@ -1257,8 +1257,30 @@ fun create_binder_datatype co (spec : spec) lthy =
           in map (Local_Defs.unfold0 lthy bmv_unfolds) (
             mk_map_simps lthy false true Sbs plives (fs @ rhos) mk_supp_bound mk_imsupp (K []) [] (#tvsubst tvsubst_res) tac
           ) end;
-        in (lthy, SOME (tvsubst_res, tvsubst_simps)) end
-      else (lthy, NONE);
+
+        in (SOME (tvsubst_res, tvsubst_simps), lthy) end
+      else (NONE, lthy);
+
+    val (tvsubst1_opt, lthy) = (case tvsubst_opt of
+        NONE => (NONE, lthy)
+      | SOME tvsubst =>
+        let
+          (* prepare spec (we need the original tv names for RVrs) *)
+          val ctor_Ts = map snd (#ctors spec);
+
+          fun is_RVr (NT, x) =
+            let
+              val Inj_count = fold (fn Ts => fn cnt =>
+                cnt + (if member (op=) Ts (TFree NT) then 1 else 0)
+              ) ctor_Ts 0;
+            in x = Free_Var andalso Inj_count <> 1 end;
+
+          val RVr_Ns = filter is_RVr (#vars spec)
+            |> map ((fn N => String.extract (N, 1, NONE)) o fst o fst);
+        in
+          TVSubst.create_tvsubst1_of_result (#tvsubst_b spec, RVr_Ns) tvsubst lthy
+          |> apfst SOME
+        end);
 
     val simp = @{attributes [simp]}
     val induct_attrib = Attrib.internal Position.none (K (Induct.induct_type (fst (dest_Type qT))))
@@ -1339,7 +1361,9 @@ fun create_binder_datatype co (spec : spec) lthy =
         ("IImsupp_permute_commute", #IImsupp_permute_commutes res, []),
         ("IImsupp_Diff", #IImsupp_Diffs res, []),
         ("tvsubst_permute", [#tvsubst_permute res], [])
-      ]) tvsubst_opt))
+      ]) tvsubst_opt) @ the_default [] (Option.map (map (fn (N, tvsubst1_simps) =>
+        (N, tvsubst1_simps, simp)
+      )) tvsubst1_opt))
         |> filter_out (null o #2)
         |> (map (fn (thmN, thms, attrs) =>
         ((Binding.qualify true (Binding.name_of (#fp_b spec)) (Binding.name thmN), attrs), [(thms, [])])

--- a/Tools/mrbnf_vvsubst.ML
+++ b/Tools/mrbnf_vvsubst.ML
@@ -126,7 +126,7 @@ fun define_vvsubst_consts qualify vvsubst_bss (fp_res : MRBNF_FP_Def_Sugar.fp_re
               foldl1 mk_Un (pset $ x :: map2 (fn rset => mk_UNION (rset $ x)) rec_sets (replicate_rec sets))
             )) sets psets (#raw_fps fp_res) rec_setss xs;
 
-            val lthy = snd (Function.add_function
+            val lthy = snd (Function.add_function {verbose=false}
               (map (fn f => (Binding.concealed (Binding.name (fst (dest_Free f))), NONE, NoSyn)) sets)
               (map (fn eq => (((Binding.concealed Binding.empty, []), eq), [], [])) eqs)
               Function_Common.default_config (fn ctxt => EVERY1 [

--- a/Tools/tvsubst.ML
+++ b/Tools/tvsubst.ML
@@ -29,6 +29,9 @@ sig
     -> MRSBNF_Def.mrsbnf -> MRBNF_Def.mrbnf -> thm -> thm -> thm list -> binding
     -> (Proof.context -> tactic) eta_model option list -> string -> local_theory
     -> tvsubst_result * local_theory
+
+  val create_tvsubst1_of_result: binding * string list -> tvsubst_result * thm list -> local_theory
+    -> (string * thm list) list * local_theory
 end
 
 structure TVSubst : TVSUBST =
@@ -2495,4 +2498,81 @@ fun create_tvsubst_of_mrsbnf qualify fp_res mrsbnf rec_mrbnf vvsubst_ctor map_pe
     }: tvsubst_result;
 
   in (result, lthy) end;
+
+local
+  fun mk_Free N T lthy' = mk_Frees N [T] lthy' |>> the_single;
+
+  fun drop_at j xs = (take j xs, drop (j+1) xs);
+in
+fun create_tvsubst1_of_result (tvsubst_b, RVr_Ns) (result, simps) lthy =
+  let
+    val Sb as Const (_, Sb_T) = #tvsubst result;
+
+    val mrsbnf = #mrsbnf result;
+
+    val bmv = MRSBNF_Def.bmv_monad_of_mrsbnf mrsbnf;
+
+    val RVrs = hd (BMV_Monad_Def.RVrs_of_bmv_monad bmv);
+    val Injs = hd (BMV_Monad_Def.Injs_of_bmv_monad bmv);
+
+    val n = length RVrs + length Injs;
+
+    val (delta_Ts, _) = fastype_of Sb |> binder_types |> split_last;
+    val (id_Ts, Inj_Ts) = partition (op= o dest_funT) delta_Ts;
+
+    (* construct the identities for RVrs and their respective unary Sb bindings *)
+    val ids = map2 (fn T => fn N => (N, Const ("Fun.id", T)))
+      id_Ts (take (length id_Ts) RVr_Ns);
+
+    (* construct the Injection ctors and their respective bindings *)
+    val Injs = map2 (fn T => dest_Const #> (fn (N, _) =>
+      (Long_Name.base_name N, Const (N, T)))
+    ) Inj_Ts Injs;
+
+    (* all together *)
+    val (Ns, trms) = split_list (ids @ Injs);
+
+    (* accumulate simplification theorems by index, name, and term: *)
+    fun alg k N trm (acc, lthy) =
+      let
+        val b = Binding.map_name (fn str => str ^ "_" ^ N) tvsubst_b;
+
+        (* "pure" terms surrounding the current delta term *)
+        val (pre, post) = drop_at k trms;
+
+        val (v_T, t_T) = fastype_of trm |> dest_funT;
+        val (t, (v, lthy_names)) = mk_Free "t" t_T lthy ||> mk_Free "v" v_T;
+
+        (* construct unary Sb definition: subst id... X{k}(v := t) Inj... *)
+        val upd = Quickcheck_Common.mk_fun_upd v_T t_T (v, t) trm;
+
+        val deltas  = pre @ upd :: post;
+        val cdeltas = map (SOME o Thm.cterm_of lthy) deltas;
+
+        val def = list_comb (Sb, deltas)
+          |> Term.absfree (dest_Free t)
+          |> Term.absfree (dest_Free v);
+
+        val ((_, (_, def_thm)), lthy) = Local_Theory.define
+          ((b, NoSyn), ((Thm.def_binding b, []), def)) lthy;
+
+        (* expand definition thm to make the Local_Defs.fold go through *)
+        val def_expanded = def_thm
+          RS @{thm meta_fun_cong} (* v *)
+          RS @{thm meta_fun_cong} (* t *)
+          RS @{thm meta_fun_cong} (* x *);
+
+        val adapt = map (
+          (* specialize the simps with unary Sb *)
+          Drule.infer_instantiate' lthy cdeltas
+          #> Local_Defs.fold lthy [def_expanded]
+          (* generalize Free variables t,v *)
+          #> singleton (Variable.export lthy_names lthy)
+        );
+
+      in (("subst_" ^ N, adapt simps) :: acc, lthy) end;
+
+  in @{fold 3} alg (0 upto n-1) Ns trms ([], lthy) end;
+end;
+
 end

--- a/Tools/tvsubst.ML
+++ b/Tools/tvsubst.ML
@@ -2625,7 +2625,8 @@ fun create_tvsubst1_of_result (tvsubst_b, RVr_Ns) (result, simps) lthy =
             let
               val fold_tac = Local_Defs.fold_tac lthy @{thms conj_assoc disj_conj_distribL};
               val unfold_tac = Local_Defs.unfold_tac lthy @{thms conj_assoc};
-            in (REPEAT (CHANGED fold_tac) THEN unfold_tac) #> Seq.hd end
+              fun disjI_tac thm = Seq.single (@{thm disjI2} RS thm) handle THM _ => Seq.empty;
+            in EVERY [REPEAT (CHANGED fold_tac), unfold_tac, TRY disjI_tac] #> Seq.hd end
           ) #> Local_Defs.fold lthy @{thms atomize_conjL};
 
         (* adapt the simp theorems to the unary case: *)

--- a/Tools/tvsubst.ML
+++ b/Tools/tvsubst.ML
@@ -2623,11 +2623,15 @@ fun create_tvsubst1_of_result (tvsubst_b, RVr_Ns) (result, simps) lthy =
           #> Local_Defs.unfold lthy @{thms int_SSupp_fun_upd_iff int_imsupp_id_fun_upd_iff int_IImsupp_fun_upd_iff Int_empty_right simp_thms(6) simp_thms(21,22) True_implies_equals}
           #> (
             let
-              val fold_tac = Local_Defs.fold_tac lthy @{thms conj_assoc disj_conj_distribL};
-              val unfold_tac = Local_Defs.unfold_tac lthy @{thms conj_assoc};
-              fun disjI_tac thm = Seq.single (@{thm disjI2} RS thm) handle THM _ => Seq.empty;
-            in EVERY [REPEAT (CHANGED fold_tac), unfold_tac, TRY disjI_tac] #> Seq.hd end
-          ) #> Local_Defs.fold lthy @{thms atomize_conjL};
+              fun RS_tac thm = TRY (fn thm' => Seq.single (thm RS thm') handle THM _ => Seq.empty)
+
+              val tac = EVERY
+                [REPEAT (CHANGED (Local_Defs.fold_tac lthy @{thms conj_assoc disj_conj_distribL})),
+                 Local_Defs.unfold_tac lthy @{thms conj_assoc},
+                 RS_tac @{thm disjI2},
+                 RS_tac @{thm conjI}]
+            in REPEAT (CHANGED tac) #> Seq.hd end
+          );
 
         (* adapt the simp theorems to the unary case: *)
         val adapt = map (

--- a/Tools/tvsubst.ML
+++ b/Tools/tvsubst.ML
@@ -2503,12 +2503,17 @@ local
   fun mk_Free N T lthy' = mk_Frees N [T] lthy' |>> the_single;
 
   fun drop_at j xs = (take j xs, drop (j+1) xs);
+
+  (* |Inj x| <o |UNIV| \<mapsto> (Inj, x) *)
+  fun dest_set_bd_UNIV (Trueprop $ (member $ (Pair $ (card_of $ (set $ x)) $ card_of_top) $ ordLess)) = (set, x)
+    | dest_set_bd_UNIV t = raise TERM("dest_set_bd_UNIV", [t])
 in
 fun create_tvsubst1_of_result (tvsubst_b, RVr_Ns) (result, simps) lthy =
   let
     val Sb as Const (_, Sb_T) = #tvsubst result;
 
     val mrsbnf = #mrsbnf result;
+    val mrbnf  = hd (MRSBNF_Def.mrbnfs_of_mrsbnf mrsbnf);
 
     val bmv = MRSBNF_Def.bmv_monad_of_mrsbnf mrsbnf;
 
@@ -2519,6 +2524,10 @@ fun create_tvsubst1_of_result (tvsubst_b, RVr_Ns) (result, simps) lthy =
 
     val (delta_Ts, _) = fastype_of Sb |> binder_types |> split_last;
     val (id_Ts, Inj_Ts) = partition (op= o dest_funT) delta_Ts;
+
+    (* map Set to fact "|Set ?x| <o |UNIV|" *)
+    val set_bd_UNIV_tab = MRBNF_Def.set_bd_UNIV_of_mrbnf mrbnf
+      |> map (`(Thm.prop_of #> dest_set_bd_UNIV #> fst #> dest_Const_name));
 
     (* construct the identities for RVrs and their respective unary Sb bindings *)
     val ids = map2 (fn T => fn N => (N, Const ("Fun.id", T)))
@@ -2562,10 +2571,56 @@ fun create_tvsubst1_of_result (tvsubst_b, RVr_Ns) (result, simps) lthy =
           RS @{thm meta_fun_cong} (* t *)
           RS @{thm meta_fun_cong} (* x *);
 
+        (* map trivial premise to theorem that discharge it *)
+        fun trivial_fact prem = case prem |> HOLogic.dest_Trueprop of
+          (* |?A| <o |UNIV| *)
+          Const (@{const_name "Set.member"}, _) $
+            (Const (@{const_name "Pair"}, _) $
+              (Const (@{const_name "card_of"}, _) $ A) $
+              (Const (@{const_name "card_of"}, _) $ Const (@{const_name "top"}, _))) $
+            Const (@{const_name "ordLess"}, _) =>
+          (case A of
+            (* {} *)
+            Const (@{const_name "bot"}, _) => @{thm emp_bound}
+            (* supp (id(v := t)) *)
+          | Const (@{const_name "supp"}, _) $
+              (Const (@{const_name "fun_upd"}, _) $ Const (@{const_name "id"}, _) $ _ $ _) =>
+            @{thm supp_fun_upd_var}
+            (* SSupp Inj (Inj(v := t)) *)
+          | Const (@{const_name "SSupp"}, _) $ _ $ (Const (@{const_name "fun_upd"}, _) $ _ $ _ $ _) =>
+            @{thm SSupp_fun_upd_Inj_bound}
+            (* IImsupp Inj ?Set (Inj(v := t) *)
+          | Const (@{const_name "IImsupp"}, _) $ _ $ Set $
+              (Const (@{const_name "fun_upd"}, _) $ _ $ _ $ _) =>
+            the (AList.lookup op= set_bd_UNIV_tab (dest_Const_name Set)) RS
+            @{thm IImsupp_fun_upd_Inj_bound}
+            (* fallback (skip) *)
+          | _ => @{thm asm_rl}
+          )
+        (* ?x \<notin> {} *)
+        | Const (@{const_name "Not"}, _) $ (Const (@{const_name "Set.member"}, _) $
+            _ $ Const (@{const_name "bot"}, _)) =>
+          @{thm empty_iff[symmetric, unfolded simp_thms(13)]}
+        (* fallback (skip) *)
+        | _ => @{thm asm_rl};
+
+        fun discharge_trivial simp_thm =
+          let
+            (* discharge premises (reverse order in case we don't fully resolve it) *)
+            val iprems = Thm.prop_of simp_thm
+              |> Logic.strip_imp_prems
+              |> map_index (fn (i, prem) => (i+1, trivial_fact prem));
+          in fold_rev (fn (i,P) => fn thm => P RSN (i, thm)) iprems simp_thm end;
+
+        (* adapt the simp theorems to the unary case: *)
         val adapt = map (
           (* specialize the simps with unary Sb *)
           Drule.infer_instantiate' lthy cdeltas
           #> Local_Defs.fold lthy [def_expanded]
+          (* unfold trivial/unary supports *)
+          #> Local_Defs.unfold lthy @{thms SSupp_Inj IImsupp_Inj supp_id imsupp_id}
+          (* discharge premises like "|{}| <o |UNIV|" etc. and tidy up *)
+          #> discharge_trivial
           (* generalize Free variables t,v *)
           #> singleton (Variable.export lthy_names lthy)
         );

--- a/Tools/tvsubst.ML
+++ b/Tools/tvsubst.ML
@@ -30,8 +30,8 @@ sig
     -> (Proof.context -> tactic) eta_model option list -> string -> local_theory
     -> tvsubst_result * local_theory
 
-  val create_tvsubst1_of_result: binding * string list -> tvsubst_result * thm list -> local_theory
-    -> (string * thm list) list * local_theory
+  val create_tvsubst1_of_result: binding * string list -> (tvsubst_result * thm list) * thm list -> local_theory
+    -> (string * thm list * Token.src list) list * local_theory
 end
 
 structure TVSubst : TVSUBST =
@@ -2506,9 +2506,16 @@ local
 
   (* |Inj x| <o |UNIV| \<mapsto> (Inj, x) *)
   fun dest_set_bd_UNIV (Trueprop $ (member $ (Pair $ (card_of $ (set $ x)) $ card_of_top) $ ordLess)) = (set, x)
-    | dest_set_bd_UNIV t = raise TERM("dest_set_bd_UNIV", [t])
+    | dest_set_bd_UNIV t = raise TERM("dest_set_bd_UNIV", [t]);
+
+  fun permute_of_type T lthy = fst (dest_Type T)
+    |> MRBNF_FP_Def_Sugar.fp_result_of lthy
+    |> the
+    |> #quotient_fps
+    |> hd
+    |> #permute
 in
-fun create_tvsubst1_of_result (tvsubst_b, RVr_Ns) (result, simps) lthy =
+fun create_tvsubst1_of_result (tvsubst_b, RVr_Ns) ((result, simps), permute_simps) lthy =
   let
     val Sb as Const (_, Sb_T) = #tvsubst result;
 
@@ -2522,7 +2529,8 @@ fun create_tvsubst1_of_result (tvsubst_b, RVr_Ns) (result, simps) lthy =
 
     val n = length RVrs + length Injs;
 
-    val (delta_Ts, _) = fastype_of Sb |> binder_types |> split_last;
+    val (delta_Ts, op_T) = fastype_of Sb |> binder_types |> split_last;
+
     val (id_Ts, Inj_Ts) = partition (op= o dest_funT) delta_Ts;
 
     (* map Set to fact "|Set ?x| <o |UNIV|" *)
@@ -2530,8 +2538,10 @@ fun create_tvsubst1_of_result (tvsubst_b, RVr_Ns) (result, simps) lthy =
       |> map (`(Thm.prop_of #> dest_set_bd_UNIV #> fst #> dest_Const_name));
 
     (* construct the identities for RVrs and their respective unary Sb bindings *)
-    val ids = map2 (fn T => fn N => (N, Const ("Fun.id", T)))
-      id_Ts (take (length id_Ts) RVr_Ns);
+    val _ = length id_Ts = length RVr_Ns orelse
+      error ("create_tvsubst1_of_result: got " ^ string_of_int (length RVr_Ns) ^
+        " RVr names for " ^ string_of_int (length id_Ts) ^ " renaming substitutions");
+    val ids = map2 (fn T => fn N => (N, Const (@{const_name id}, T))) id_Ts RVr_Ns;
 
     (* construct the Injection ctors and their respective bindings *)
     val Injs = map2 (fn T => dest_Const #> (fn (N, _) =>
@@ -2547,16 +2557,33 @@ fun create_tvsubst1_of_result (tvsubst_b, RVr_Ns) (result, simps) lthy =
         val (_, lthy) = Local_Theory.begin_nested lthy;
         val b = Binding.map_name (fn str => str ^ "_" ^ N) tvsubst_b;
 
-        (* "pure" terms surrounding the current delta term *)
-        val (pre, post) = drop_at k trms;
+        (* terms surrounding the current term *)
+        val (pre_trm, post_trm) = drop_at k trms;
 
         val (v_T, t_T) = fastype_of trm |> dest_funT;
-        val (t, (v, names_lthy)) = mk_Free "t" t_T lthy ||> mk_Free "v" v_T;
+
+        val (permute, lthy) = permute_of_type op_T lthy
+          |> (fn trm => Variable.importT_terms [trm] lthy)
+          |>> the_single;
+
+        val (permute_Ts, _) = fastype_of permute
+          |> binder_types
+          |> split_last;
+
+        val (((gs, t), v), names_lthy) = lthy
+          |> mk_Frees "g" permute_Ts |>> I
+          ||>> mk_Free "t" t_T
+          ||>> mk_Free "v" v_T;
+
+        val is_RVr = k < length ids;
+
+        val g_opt = map_index I gs
+          |> List.find (fn (_,g) => domain_type (fastype_of g) = v_T);
 
         (* construct unary Sb definition: subst id... X{k}(v := t) Inj... *)
         val upd = Quickcheck_Common.mk_fun_upd v_T t_T (v, t) trm;
 
-        val deltas  = pre @ upd :: post;
+        val deltas  = pre_trm @ upd :: post_trm;
         val cdeltas = map (SOME o Thm.cterm_of lthy) deltas;
 
         val def = list_comb (Sb, deltas)
@@ -2566,11 +2593,10 @@ fun create_tvsubst1_of_result (tvsubst_b, RVr_Ns) (result, simps) lthy =
         val ((_, (_, def_thm)), lthy) = Local_Theory.define
           ((b, NoSyn), ((Thm.def_binding b, []), def)) lthy;
 
-        (* expand definition thm to make the Local_Defs.fold go through *)
-        val def_expanded = def_thm
-          RS @{thm meta_fun_cong} (* v *)
-          RS @{thm meta_fun_cong} (* t *)
-          RS @{thm meta_fun_cong} (* x *);
+        (* expand definition thm to make the Local_Defs.fold go through (v,t,x) *)
+        val (def3, def2) =
+          (def_thm RS @{thm meta_fun_cong} RS @{thm meta_fun_cong})
+          |> `(fn thm => thm RS @{thm meta_fun_cong});
 
         (* map trivial premise to theorem that discharge it *)
         fun trivial_fact prem = case prem |> HOLogic.dest_Trueprop of
@@ -2605,13 +2631,13 @@ fun create_tvsubst1_of_result (tvsubst_b, RVr_Ns) (result, simps) lthy =
         (* fallback (skip) *)
         | _ => @{thm asm_rl};
 
-        fun discharge_trivial simp_thm =
+        fun discharge_trivial thm =
           let
             (* discharge premises (reverse order in case we don't fully resolve it) *)
-            val iprems = Thm.prop_of simp_thm
+            val iprems = Thm.prop_of thm
               |> Logic.strip_imp_prems
               |> map_index (fn (i, prem) => (i+1, trivial_fact prem));
-          in fold_rev (fn (i,P) => fn thm => P RSN (i, thm)) iprems simp_thm end;
+          in fold_rev (fn (i,P) => fn thm => P RSN (i, thm)) iprems thm end;
 
         (* get rid of all SSupp, IImssupp, SSupp, and imsupp mentions: *)
         val tidy =
@@ -2634,21 +2660,82 @@ fun create_tvsubst1_of_result (tvsubst_b, RVr_Ns) (result, simps) lthy =
           );
 
         (* adapt the simp theorems to the unary case: *)
-        val adapt = map (
+        val simps1 = map (
           (* specialize the simps with unary Sb *)
           Drule.infer_instantiate' lthy cdeltas
-          #> Local_Defs.fold lthy [def_expanded]
+          #> Local_Defs.fold lthy [def3]
           (* unfold trivial/unary supports *)
           #> Local_Defs.unfold lthy @{thms SSupp_Inj IImsupp_Inj supp_id imsupp_id}
           (* discharge premises like "|{}| <o |UNIV|" etc. and tidy up *)
           #> discharge_trivial
           #> tidy
           #> singleton (Variable.export names_lthy lthy)
-        );
+        ) simps;
+
+        (* permute gs \<circ> Inj(v := x) \<circ> inv g = Inj(g v := permute gs x) *)
+        val equiv_opt = case g_opt of
+          NONE => (warning ("No permutation argument for type " ^
+            Syntax.string_of_typ lthy v_T ^ "; skipping equivariance theorem for " ^
+            Binding.name_of b); NONE)
+        | SOME (j, g) =>
+          let
+            val cgs = map (SOME o Thm.cterm_of lthy) gs;
+
+            val permute_g = if is_RVr then g else list_comb (permute, gs);
+
+            (* instantiate tvsubst_permute and obtain equivariance theorem *)
+            val equiv_thm0 = #tvsubst_permute result
+              |> Drule.infer_instantiate' lthy (cgs @ cdeltas)
+              |> Local_Defs.fold lthy [def2]
+              |> Local_Defs.unfold lthy @{thms SSupp_Inj IImsupp_Inj supp_id imsupp_id}
+              |> discharge_trivial;
+
+            val bij_fact = Thm.assume (Thm.cprem_of equiv_thm0 (2*j + 1)); (* bij g *)
+
+            val discharge_prems = fold (fn fact => fn thm =>
+              Thm.assume fact RS thm handle THM _ => thm) (Thm.cprems_of equiv_thm0);
+            fun bij_RS thm = Thm.cprems_of equiv_thm0
+              |> map (fn fact => (Thm.assume fact RS thm) handle THM _ => @{thm refl});
+
+            (* permute_g \<circ> trm \<circ> inv g = trm *)
+            val g_prems = maps (fn g => map HOLogic.mk_Trueprop
+              [mk_bij g, MRBNF_Util.mk_supp_bound g]) gs;
+            val inner = Goal.prove names_lthy [] g_prems
+              (HOLogic.mk_Trueprop (HOLogic.mk_eq
+                (HOLogic.mk_comp (HOLogic.mk_comp (permute_g, trm), MRBNF_Util.mk_inv g), trm)))
+              (fn {context = ctxt, prems} => EVERY1 [
+                rtac ctxt @{thm ext},
+                K (Local_Defs.unfold0_tac ctxt (@{thms o_apply id_apply}
+                  @ map (fold (fn p => fn thm => p RS thm handle THM _ => thm) prems) permute_simps
+                  @ map_filter (fn p => try (fn () => p RS @{thm inv_simp2}) ()) prems)),
+                rtac ctxt refl
+              ])
+              |> discharge_prems;
+
+            (* permute_g \<circ> trm(v := t) \<circ> inv g = trm(g v := permute_g t) *)
+            val eq = (bij_fact RS @{thm fun_upd_comp_inv})
+              |> Drule.infer_instantiate' lthy (map (SOME o Thm.cterm_of lthy) [permute_g, trm, v, t])
+              |> Local_Defs.unfold lthy [inner RS @{thm eq_reflection}];
+
+            val permute_simps = map discharge_prems permute_simps;
+          in
+            (Local_Defs.unfold lthy
+              ((eq RS @{thm eq_reflection}) :: @{thm o_id} :: bij_RS @{thm inv_o_simp2})
+              equiv_thm0 RS @{thm o_eq_dest})
+            |> Local_Defs.unfold lthy (@{thm o_def} :: permute_simps @ bij_RS @{thm inv_simp2})
+            |> Local_Defs.fold lthy [def2]
+            |> singleton (Variable.export names_lthy lthy)
+            |> SOME
+          end;
+
         val (lthy, old_lthy) = `Local_Theory.end_nested lthy;
         val phi = Proof_Context.export_morphism old_lthy lthy;
 
-      in (("subst_" ^ N, adapt simps |> Morphism.fact phi) :: acc, lthy) end;
+        val notes =
+          [("subst_" ^ N, Morphism.fact phi simps1, @{attributes [simp]}),
+           ("subst_" ^ N ^ "_equiv", Morphism.fact phi (the_list equiv_opt), @{attributes [equiv]})];
+
+      in (notes @ acc, lthy) end;
 
   in @{fold 3} alg (0 upto n-1) Ns trms ([], lthy) end;
 end;

--- a/Tools/tvsubst.ML
+++ b/Tools/tvsubst.ML
@@ -2544,13 +2544,14 @@ fun create_tvsubst1_of_result (tvsubst_b, RVr_Ns) (result, simps) lthy =
     (* accumulate simplification theorems by index, name, and term: *)
     fun alg k N trm (acc, lthy) =
       let
+        val (_, lthy) = Local_Theory.begin_nested lthy;
         val b = Binding.map_name (fn str => str ^ "_" ^ N) tvsubst_b;
 
         (* "pure" terms surrounding the current delta term *)
         val (pre, post) = drop_at k trms;
 
         val (v_T, t_T) = fastype_of trm |> dest_funT;
-        val (t, (v, lthy_names)) = mk_Free "t" t_T lthy ||> mk_Free "v" v_T;
+        val (t, (v, names_lthy)) = mk_Free "t" t_T lthy ||> mk_Free "v" v_T;
 
         (* construct unary Sb definition: subst id... X{k}(v := t) Inj... *)
         val upd = Quickcheck_Common.mk_fun_upd v_T t_T (v, t) trm;
@@ -2637,11 +2638,12 @@ fun create_tvsubst1_of_result (tvsubst_b, RVr_Ns) (result, simps) lthy =
           (* discharge premises like "|{}| <o |UNIV|" etc. and tidy up *)
           #> discharge_trivial
           #> tidy
-          (* generalize Free variables t,v *)
-          #> singleton (Variable.export lthy_names lthy)
+          #> singleton (Variable.export names_lthy lthy)
         );
+        val (lthy, old_lthy) = `Local_Theory.end_nested lthy;
+        val phi = Proof_Context.export_morphism old_lthy lthy;
 
-      in (("subst_" ^ N, adapt simps) :: acc, lthy) end;
+      in (("subst_" ^ N, adapt simps |> Morphism.fact phi) :: acc, lthy) end;
 
   in @{fold 3} alg (0 upto n-1) Ns trms ([], lthy) end;
 end;

--- a/Tools/tvsubst.ML
+++ b/Tools/tvsubst.ML
@@ -2612,6 +2612,21 @@ fun create_tvsubst1_of_result (tvsubst_b, RVr_Ns) (result, simps) lthy =
               |> map_index (fn (i, prem) => (i+1, trivial_fact prem));
           in fold_rev (fn (i,P) => fn thm => P RSN (i, thm)) iprems simp_thm end;
 
+        (* get rid of all SSupp, IImssupp, SSupp, and imsupp mentions: *)
+        val tidy =
+          (* unfold "x \<notin> {IImssupp,SSupp,imsupp} .." \<leadsto> "t = Var v \<or> ..." *)
+          Local_Defs.unfold lthy @{thms not_in_SSupp_fun_upd_Inj_iff not_in_IImsupp_fun_upd_Inj_iff not_in_imsupp_fun_upd_id_iff}
+          (* rewrite \<lbrakk> t = Var v \<or> ?A1; t = Var v \<or> ?A2 ... \<rbrakk> \<leadsto> \<lbrakk> t = Var \<or> (?A1 \<and> ...); ... \<rbrakk> *)
+          #> Local_Defs.unfold lthy @{thms atomize_conjL}
+          (* tidy up a bit *)
+          #> Local_Defs.unfold lthy @{thms int_SSupp_fun_upd_iff int_imsupp_id_fun_upd_iff int_IImsupp_fun_upd_iff Int_empty_right simp_thms(6) simp_thms(21,22) True_implies_equals}
+          #> (
+            let
+              val fold_tac = Local_Defs.fold_tac lthy @{thms conj_assoc disj_conj_distribL};
+              val unfold_tac = Local_Defs.unfold_tac lthy @{thms conj_assoc};
+            in (REPEAT (CHANGED fold_tac) THEN unfold_tac) #> Seq.hd end
+          ) #> Local_Defs.fold lthy @{thms atomize_conjL};
+
         (* adapt the simp theorems to the unary case: *)
         val adapt = map (
           (* specialize the simps with unary Sb *)
@@ -2621,6 +2636,7 @@ fun create_tvsubst1_of_result (tvsubst_b, RVr_Ns) (result, simps) lthy =
           #> Local_Defs.unfold lthy @{thms SSupp_Inj IImsupp_Inj supp_id imsupp_id}
           (* discharge premises like "|{}| <o |UNIV|" etc. and tidy up *)
           #> discharge_trivial
+          #> tidy
           (* generalize Free variables t,v *)
           #> singleton (Variable.export lthy_names lthy)
         );

--- a/tests/Regression_Tests.thy
+++ b/tests/Regression_Tests.thy
@@ -7,6 +7,9 @@ binder_datatype 'a trm =
   Var 'a
 | Abs x::'a t::"'a trm" binds x in t
 
+thm trm.subst
+thm trm.subst_Var
+
 (* #69 *)
 binder_datatype 'a LLC =
   Var 'a

--- a/thys/Classes.thy
+++ b/thys/Classes.thy
@@ -114,6 +114,7 @@ lemma IImsupp_Inj_comp_bound1: "inj Inj \<Longrightarrow> |supp (f::'a::var \<Ri
 
 lemma IImsupp_Inj_comp_bound2: "(\<And>a. Vrs (Inj a) = {}) \<Longrightarrow> |IImsupp Inj Vrs (Inj \<circ> f)| <o |UNIV::'a set|"
   by (auto simp: IImsupp_def)
+
 lemmas IImsupp_Inj_comp_bound = IImsupp_Inj_comp_bound1 IImsupp_Inj_comp_bound2
 
 lemma SSupp_fun_upd_bound_UNIV[simp]: "|SSupp Inj (f(x := t))| <o |UNIV::'a::var set| \<longleftrightarrow> |SSupp Inj f| <o |UNIV::'a set|"
@@ -121,7 +122,11 @@ lemma SSupp_fun_upd_bound_UNIV[simp]: "|SSupp Inj (f(x := t))| <o |UNIV::'a::var
 
 lemma SSupp_fun_upd_Inj_bound[simp]: "|SSupp Inj (Inj(x := t))| <o |UNIV::'a::var set|"
   by simp
+
 lemma IImsupp_fun_upd_Inj_bound[simp, intro!]: "(\<And>x. |Vrs x| <o |UNIV::'a::var set| ) \<Longrightarrow> |IImsupp Inj Vrs (Inj(x := t))| <o |UNIV::'a::var set|"
   unfolding IImsupp_def by (meson SSupp_fun_upd_Inj_bound UN_bound)
+
+lemma supp_fun_upd_var: "|supp (id(v::'a::var := t))| <o |UNIV::'a set|"
+  by (simp add: supp_def)
 
 end

--- a/thys/MRBNF_FP.thy
+++ b/thys/MRBNF_FP.thy
@@ -522,15 +522,15 @@ val _ = extra_assms |> map (Thm.pretty_thm ctxt #> verbose ? @{print tracing});
                 Method.insert_tac ctxt (assms @ extra_assms @ fprems) THEN'
                 SELECT_GOAL (unfold_tac ctxt defs) THEN'
                 K (if verbose then print_tac ctxt "pre_auto" else all_tac) THEN'
-                SELECT_GOAL (mk_auto_tac (ctxt
-                  addsimps (simp_thms @ defs @ fprems)
+                SELECT_GOAL (mk_auto_tac ((ctxt
+                  |> Simplifier.add_simps (simp_thms @ defs @ fprems))
                   addSIs (ex_f :: id_onI @ intro_thms)
                   addSEs elim_thms) 0 10) THEN_ALL_NEW (SELECT_GOAL (print_tac ctxt "auto failed")))
             end;
-          val small_ctxt = ctxt addsimps small_thms addIs small_thms;
+          val small_ctxt = (ctxt |> Simplifier.add_simps small_thms) addIs small_thms;
         in
           HEADGOAL (rtac ctxt (fresh RS exE) THEN'
-          SELECT_GOAL (auto_tac (small_ctxt addsimps [hd defs])) THEN'
+          SELECT_GOAL (auto_tac (small_ctxt |> Simplifier.add_simps [hd defs])) THEN'
           REPEAT_DETERM_N 2 o (asm_simp_tac small_ctxt) THEN'
           SELECT_GOAL (unfold_tac ctxt @{thms Int_Un_distrib Un_empty}) THEN'
           REPEAT_DETERM o etac ctxt conjE THEN'

--- a/thys/Support.thy
+++ b/thys/Support.thy
@@ -86,6 +86,31 @@ lemma IImsupp_type_copy: "type_definition Rep Abs UNIV \<Longrightarrow> IImsupp
 lemma notin_SSupp: "a \<notin> SSupp Inj f \<Longrightarrow> f a = Inj a"
   unfolding SSupp_def by blast
 
+lemma not_in_SSupp_fun_upd_Inj_iff:
+  \<open>u \<notin> SSupp Inj (Inj(v := t)) \<longleftrightarrow> t = Inj v \<or> u \<noteq> v\<close>
+  by (simp add: SSupp_def)
+
+lemma not_in_IImsupp_fun_upd_Inj_iff:
+  \<open>u \<notin> IImsupp Inj Set (Inj(v := t)) \<longleftrightarrow> t = Inj v \<or> u \<notin> Set t\<close>
+  by (simp add: IImsupp_def SSupp_def)
+
+lemma not_in_imsupp_fun_upd_id_iff:
+  \<open>u \<notin> imsupp (id(v := t)) \<longleftrightarrow> t = v \<or> (u \<noteq> v \<and> u \<noteq> t)\<close>
+  by (auto simp: imsupp_def supp_def)
+
+lemma int_SSupp_fun_upd_iff:
+  \<open>A \<inter> SSupp Inj (Inj(v := t)) = {} \<longleftrightarrow> t = Inj v \<or> v \<notin> A\<close>
+  by (auto simp: SSupp_def)
+
+lemma int_imsupp_id_fun_upd_iff:
+  \<open>A \<inter> imsupp (id(v := t)) = {} \<longleftrightarrow> t = v \<or> v \<notin> A \<and> t \<notin> A\<close>
+  by (simp add: imsupp_id_fun_upd)
+
+lemma int_IImsupp_fun_upd_iff:
+  \<open>A \<inter> IImsupp Inj Vrs (Inj(v := t)) = {} \<longleftrightarrow>
+   t = Inj v \<or> A \<inter> Vrs t = {}\<close>
+  by (simp add: IImsupp_def SSupp_def)
+
 lemma IImsupp_chain1:
   assumes "\<And>a. Vrs2 (Inj2 a) = {a}" "\<rho>1 = \<rho>' \<or> \<rho>1 = \<rho>2"
   shows "(\<Union>x\<in>SSupp Inj2 \<rho>1. \<Union>x\<in>Vrs2 (\<rho>' x). Vrs2 (\<rho>2 x)) \<subseteq> IImsupp Inj2 Vrs2 \<rho>2 \<union> IImsupp Inj2 Vrs2 \<rho>'"

--- a/thys/Support.thy
+++ b/thys/Support.thy
@@ -111,6 +111,10 @@ lemma int_IImsupp_fun_upd_iff:
    t = Inj v \<or> A \<inter> Vrs t = {}\<close>
   by (simp add: IImsupp_def SSupp_def)
 
+lemma fun_upd_comp_inv:
+  \<open>bij g \<Longrightarrow> (h \<circ> f(v := t)) \<circ> inv g = (h \<circ> f \<circ> inv g)(g v := h t)\<close>
+  by (rule ext) (auto simp: bij_inv_eq_iff)
+
 lemma IImsupp_chain1:
   assumes "\<And>a. Vrs2 (Inj2 a) = {a}" "\<rho>1 = \<rho>' \<or> \<rho>1 = \<rho>2"
   shows "(\<Union>x\<in>SSupp Inj2 \<rho>1. \<Union>x\<in>Vrs2 (\<rho>' x). Vrs2 (\<rho>2 x)) \<subseteq> IImsupp Inj2 Vrs2 \<rho>2 \<union> IImsupp Inj2 Vrs2 \<rho>'"


### PR DESCRIPTION
Draft implementation for #19: adds `TVSubst.create_tvsubst1_of_result` and hooks it up in mrbnf_sugar.ML

1. This implementation picks apart the simp theorem's premises and discharges cardinality assumptions this way. We could use something like
  ```SML

  val set_bd_UNIV_tab = MRBNF_Def.set_bd_UNIV_of_mrbnf mrbnf
    |> take (nRVrs + length Vrs)
    |> map (`(Drule.infer_instantiate' lthy [SOME (Thm.cterm_of lthy x)]
      #> Thm.full_prop_of
      #> (dest_set_bd_UNIV #> fst #> fastype_of #> range_type #> HOLogic.dest_setT)
    ));

  (* ... *)

  val small_support_prems = map2 (fn T => fn i =>
    let
      val typ_equiv = Sign.typ_equiv (Proof_Context.theory_of lthy);
      val (dom_T, range_T) = dest_funT T;

      val bds = filter (fn (T, _) =>
        typ_equiv (range_T, mrbnf_T) andalso not (typ_equiv (dom_T, T))
      ) set_bd_UNIV_tab |> map snd;
    in
      case (i < nRVrs, i = k) of
      (true, true) => (* this RVr is current trm: *) @{thms supp_fun_upd_var} 
    | (true, _) => (* this RVr is id: *) @{thms supp_id_bound}
    | (false, true) => (* this Inj is current trm: *)
        @{thm SSupp_fun_upd_Inj_bound} ::
        map (fn thm => thm RS @{thm IImsupp_fun_upd_Inj_bound}) bds
    | _ => (* this Inj is "pure": *)
      @{thm SSupp_Inj_bound} ::
      map (K @{thm IImsupp_Inj_bound}) bds
    end
  ) delta_Ts ixs |> flat;
  ```
   to construct them a priori but this seems brittle against "upstream" changes (the ordering of `IImsupp` premises is not straight-forward either and unnecessarily complicates things). Matching premises to cardinality theorems (or `asm_rl`) is much simpler.

2. I also added a `tidy` pass over the simp theorems (latest commit) which gets rid of all constants from Support.thy (e.g. `IImsupp`) and yields more familiar theorems. This is a personal choice, open to discussion.